### PR TITLE
[FLX-112] Validate required ENV vars

### DIFF
--- a/internal/config/constants/general.go
+++ b/internal/config/constants/general.go
@@ -1,6 +1,7 @@
 package constants
 
 const (
+	JWTSecretMinLength      = 32
 	XProjectHeaderName      = "X-Project"
 	BackupContainerName     = "fluxend-client-database-backups"
 	StorageDriverFilesystem = "FILESYSTEM"


### PR DESCRIPTION
**Why**
Misconfiguration can cause heartache and pulled out hair. This can be avoided if API server validates configs and common pitfalls and throws appropriate errors

**What changes**
- Ensures required `.env` variables are present
- `JWT_SECRET` is of minimum 32 chars