### PR TITLE
[FLX-113] Extend health endpoint

### DIFF
--- a/internal/api/handlers/health.go
+++ b/internal/api/handlers/health.go
@@ -31,6 +31,7 @@ func NewHealthHandler(injector *do.Injector) (*HealthHandler, error) {
 //
 // @Success 200 {object} response.Response{content=dto.GenericResponse} "Health status"
 // @Failure 401 "Unauthorized"
+// @Failure 403 "Forbidden"
 //
 // @Router /admin/health [get]
 func (hh *HealthHandler) Pulse(c echo.Context) error {

--- a/internal/domain/health/entity.go
+++ b/internal/domain/health/entity.go
@@ -7,9 +7,6 @@ type Health struct {
 	PostgrestStatus string `json:"postgrest_status"`
 
 	// System Resources
-	RamUsage      string `json:"ram_usage"`
-	RamAvailable  string `json:"ram_available"`
-	RamTotal      string `json:"ram_total"`
 	DiskUsage     string `json:"disk_usage"`
 	DiskAvailable string `json:"disk_available"`
 	DiskTotal     string `json:"disk_total"`

--- a/internal/domain/health/entity.go
+++ b/internal/domain/health/entity.go
@@ -1,7 +1,18 @@
 package health
 
 type Health struct {
+	// Service Status
 	DatabaseStatus  string `json:"database_status"`
 	AppStatus       string `json:"app_status"`
 	PostgrestStatus string `json:"postgrest_status"`
+
+	// System Resources
+	RamUsage      string `json:"ram_usage"`
+	RamAvailable  string `json:"ram_available"`
+	RamTotal      string `json:"ram_total"`
+	DiskUsage     string `json:"disk_usage"`
+	DiskAvailable string `json:"disk_available"`
+	DiskTotal     string `json:"disk_total"`
+	CPUUsage      string `json:"cpu_usage"`
+	CPUCores      int    `json:"cpu_cores"`
 }

--- a/internal/domain/health/service.go
+++ b/internal/domain/health/service.go
@@ -1,12 +1,23 @@
 package health
 
 import (
+	"bufio"
 	"fluxend/internal/domain/admin"
 	"fluxend/internal/domain/auth"
 	"fluxend/internal/domain/project"
 	"fluxend/internal/domain/setting"
 	"fluxend/internal/domain/shared"
+	"fluxend/pkg"
 	"fluxend/pkg/errors"
+	"fmt"
+	"github.com/rs/zerolog/log"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
 	"github.com/samber/do"
 )
 
@@ -43,24 +54,122 @@ func (s *ServiceImpl) Pulse(authUser auth.User) (Health, error) {
 		return Health{}, errors.NewForbiddenError("setting.error.listForbidden")
 	}
 
+	diskTotal, diskAvailable, diskUsed, err := s.getDiskStats("/")
+	if err != nil {
+		return Health{}, fmt.Errorf("failed to get disk stats: %w", err)
+	}
+
+	cpuUsage, err := s.getCPUUsage()
+	if err != nil {
+		return Health{}, fmt.Errorf("failed to get CPU usage: %w", err)
+	}
+
 	response := Health{
 		DatabaseStatus:  statusOk,
 		AppStatus:       statusOk,
 		PostgrestStatus: statusOk,
+
+		DiskUsage:     pkg.FormatPercentage(diskUsed, diskTotal),
+		DiskAvailable: pkg.FormatBytes(diskAvailable),
+		DiskTotal:     pkg.FormatBytes(diskTotal),
+		CPUUsage:      cpuUsage,
+		CPUCores:      runtime.NumCPU(),
 	}
 
 	allProjects, err := s.projectRepo.List(shared.PaginationParams{})
 	if err != nil {
-		return Health{}, err
-	}
+		response.DatabaseStatus = statusError
 
-	for _, currentProject := range allProjects {
-		if !s.postgrestService.HasContainer(currentProject.DBName) {
-			response.PostgrestStatus = statusError
-
-			break
+		log.Error().Msg("Failed to list projects: " + err.Error())
+	} else {
+		for _, currentProject := range allProjects {
+			if !s.postgrestService.HasContainer(currentProject.DBName) {
+				response.PostgrestStatus = statusError
+				break
+			}
 		}
 	}
 
 	return response, nil
+}
+
+func (s *ServiceImpl) getDiskStats(path string) (total, available, used uint64, err error) {
+	var stat syscall.Statfs_t
+	err = syscall.Statfs(path, &stat)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	total = stat.Blocks * uint64(stat.Bsize)
+	available = stat.Bavail * uint64(stat.Bsize)
+	used = total - available
+
+	return total, available, used, nil
+}
+
+func (s *ServiceImpl) getCPUStats() (cpuStats, error) {
+	file, err := os.Open("/proc/stat")
+	if err != nil {
+		return cpuStats{}, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "cpu ") {
+			fields := strings.Fields(line)
+			if len(fields) >= 8 {
+				stats := cpuStats{}
+				stats.user, _ = strconv.ParseUint(fields[1], 10, 64)
+				stats.nice, _ = strconv.ParseUint(fields[2], 10, 64)
+				stats.system, _ = strconv.ParseUint(fields[3], 10, 64)
+				stats.idle, _ = strconv.ParseUint(fields[4], 10, 64)
+				stats.iowait, _ = strconv.ParseUint(fields[5], 10, 64)
+				stats.irq, _ = strconv.ParseUint(fields[6], 10, 64)
+				stats.softirq, _ = strconv.ParseUint(fields[7], 10, 64)
+				if len(fields) > 8 {
+					stats.steal, _ = strconv.ParseUint(fields[8], 10, 64)
+				}
+				return stats, nil
+			}
+		}
+	}
+	return cpuStats{}, fmt.Errorf("cpu stats not found")
+}
+
+func (s *ServiceImpl) getCPUUsage() (string, error) {
+	// Get initial reading
+	prev, err := s.getCPUStats()
+	if err != nil {
+		return "0%", err
+	}
+
+	// Wait a brief moment
+	time.Sleep(100 * time.Millisecond)
+
+	// Get second reading
+	curr, err := s.getCPUStats()
+	if err != nil {
+		return "0%", err
+	}
+
+	prevIdle := prev.idle + prev.iowait
+	currIdle := curr.idle + curr.iowait
+
+	prevNonIdle := prev.user + prev.nice + prev.system + prev.irq + prev.softirq + prev.steal
+	currNonIdle := curr.user + curr.nice + curr.system + curr.irq + curr.softirq + curr.steal
+
+	prevTotal := prevIdle + prevNonIdle
+	currTotal := currIdle + currNonIdle
+
+	totalDiff := currTotal - prevTotal
+	idleDiff := currIdle - prevIdle
+
+	if totalDiff == 0 {
+		return "0%", nil
+	}
+
+	cpuUsage := float64(totalDiff-idleDiff) / float64(totalDiff) * 100
+	return fmt.Sprintf("%.1f%%", cpuUsage), nil
 }

--- a/internal/domain/health/service.go
+++ b/internal/domain/health/service.go
@@ -5,7 +5,6 @@ import (
 	"fluxend/internal/domain/admin"
 	"fluxend/internal/domain/auth"
 	"fluxend/internal/domain/project"
-	"fluxend/internal/domain/setting"
 	"fluxend/internal/domain/shared"
 	"fluxend/pkg"
 	"fluxend/pkg/errors"
@@ -30,20 +29,17 @@ type Service interface {
 
 type ServiceImpl struct {
 	adminPolicy      *admin.Policy
-	settingRepo      setting.Repository
 	projectRepo      project.Repository
 	postgrestService shared.PostgrestService
 }
 
 func NewHealthService(injector *do.Injector) (Service, error) {
 	policy := admin.NewAdminPolicy()
-	settingRepo := do.MustInvoke[setting.Repository](injector)
 	projectRepo := do.MustInvoke[project.Repository](injector)
 	postgrestService := do.MustInvoke[shared.PostgrestService](injector)
 
 	return &ServiceImpl{
 		adminPolicy:      policy,
-		settingRepo:      settingRepo,
 		projectRepo:      projectRepo,
 		postgrestService: postgrestService,
 	}, nil

--- a/internal/domain/health/types.go
+++ b/internal/domain/health/types.go
@@ -1,0 +1,12 @@
+package health
+
+type cpuStats struct {
+	user    uint64
+	nice    uint64
+	system  uint64
+	idle    uint64
+	iowait  uint64
+	irq     uint64
+	softirq uint64
+	steal   uint64
+}

--- a/pkg/size_conversion.go
+++ b/pkg/size_conversion.go
@@ -1,5 +1,30 @@
 package pkg
 
+import (
+	"fmt"
+)
+
 func ConvertBytesToKiloBytes(bytes int) int {
 	return bytes / 1024
+}
+
+func FormatBytes(bytes uint64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}
+
+func FormatPercentage(used, total uint64) string {
+	if total == 0 {
+		return "0%"
+	}
+	percentage := float64(used) / float64(total) * 100
+	return fmt.Sprintf("%.1f%%", percentage)
 }


### PR DESCRIPTION
**Why**
The current endpoint only returns status of system. It doesn't provide details about disk and cpu usage. 

**What changes**
- Introduce `disk_usage` which percentage of disk used
- Introduce `disk_available` which shows available space
- Introduce `disk_total`
- Introduce `cpu_usage` to show CPU usage in percentage
- Introduce `cpu_cores`