### PR TITLE
FLX-114: Create default organization on signup

### DIFF
--- a/internal/api/dto/user/responses.go
+++ b/internal/api/dto/user/responses.go
@@ -5,12 +5,13 @@ import (
 )
 
 type Response struct {
-	Uuid      uuid.UUID `json:"uuid"`
-	Username  string    `json:"username"`
-	Email     string    `json:"email"`
-	Status    string    `json:"status"`
-	RoleID    int       `json:"roleId"`
-	Bio       string    `json:"bio"`
-	CreatedAt string    `json:"createdAt"`
-	UpdatedAt string    `json:"updatedAt"`
+	Uuid             uuid.UUID `json:"uuid"`
+	OrganizationUuid uuid.UUID `json:"organizationUuid"`
+	Username         string    `json:"username"`
+	Email            string    `json:"email"`
+	Status           string    `json:"status"`
+	RoleID           int       `json:"roleId"`
+	Bio              string    `json:"bio"`
+	CreatedAt        string    `json:"createdAt"`
+	UpdatedAt        string    `json:"updatedAt"`
 }

--- a/internal/api/mapper/user.go
+++ b/internal/api/mapper/user.go
@@ -7,14 +7,15 @@ import (
 
 func ToUserResource(user *userDomain.User) userDto.Response {
 	return userDto.Response{
-		Uuid:      user.Uuid,
-		Username:  user.Username,
-		Email:     user.Email,
-		Status:    user.Status,
-		RoleID:    user.RoleID,
-		Bio:       user.Bio,
-		CreatedAt: user.CreatedAt.Format("2006-01-02 15:04:05"),
-		UpdatedAt: user.UpdatedAt.Format("2006-01-02 15:04:05"),
+		Uuid:             user.Uuid,
+		OrganizationUuid: user.OrganizationUuid,
+		Username:         user.Username,
+		Email:            user.Email,
+		Status:           user.Status,
+		RoleID:           user.RoleID,
+		Bio:              user.Bio,
+		CreatedAt:        user.CreatedAt.Format("2006-01-02 15:04:05"),
+		UpdatedAt:        user.UpdatedAt.Format("2006-01-02 15:04:05"),
 	}
 }
 

--- a/internal/config/constants/general.go
+++ b/internal/config/constants/general.go
@@ -1,6 +1,7 @@
 package constants
 
 const (
+	DefaultOrganizationName = "Default"
 	JWTSecretMinLength      = 32
 	XProjectHeaderName      = "X-Project"
 	BackupContainerName     = "fluxend-client-database-backups"

--- a/internal/domain/user/entity.go
+++ b/internal/domain/user/entity.go
@@ -9,15 +9,16 @@ import (
 
 type User struct {
 	shared.BaseEntity
-	Uuid      uuid.UUID `db:"uuid"`
-	Username  string    `db:"username"`
-	Email     string    `db:"email"`
-	Status    string    `db:"status"`
-	RoleID    int       `db:"role_id"`
-	Bio       string    `db:"bio"`
-	Password  string    `db:"password"`
-	CreatedAt time.Time `db:"created_at"`
-	UpdatedAt time.Time `db:"updated_at"`
+	Uuid             uuid.UUID `db:"uuid"`
+	Username         string    `db:"username"`
+	Email            string    `db:"email"`
+	Status           string    `db:"status"`
+	RoleID           int       `db:"role_id"`
+	Bio              string    `db:"bio"`
+	OrganizationUuid uuid.UUID `db:"organization_uuid"` // TODO: remove default org after alpha release
+	Password         string    `db:"password"`
+	CreatedAt        time.Time `db:"created_at"`
+	UpdatedAt        time.Time `db:"updated_at"`
 }
 
 func (u User) IsActive() bool {


### PR DESCRIPTION
**Why**
We have organizations functionality on backend. Though, we won't be releasing UI for this in Alpha release. Instead, we'll create organization automatically. It stays hidden under the hood for now.

We'll introduce this in upcoming versions after we've stabilized other parts of app first. 

**What changes**
- Update user handler to create organization upon successful signup
- Update user DTO and response to include `organizationUuid`