### PR TITLE
[Feat] Add endpoint to show info of logged in user

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -60,6 +60,9 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized"
+                    },
+                    "403": {
+                        "description": "Forbidden"
                     }
                 }
             }
@@ -4700,6 +4703,56 @@ const docTemplate = `{
                 }
             }
         },
+        "/users/me": {
+            "get": {
+                "description": "Get details of logged-in specific user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Retrieve logged-in user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bearer Token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User details",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/response.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "content": {
+                                            "$ref": "#/definitions/user.Response"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "500": {
+                        "description": "Internal server error"
+                    }
+                }
+            }
+        },
         "/users/{userUUID}": {
             "get": {
                 "description": "Get details of a specific user",
@@ -5746,6 +5799,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "email": {
+                    "type": "string"
+                },
+                "organizationUuid": {
                     "type": "string"
                 },
                 "roleId": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -52,6 +52,9 @@
                     },
                     "401": {
                         "description": "Unauthorized"
+                    },
+                    "403": {
+                        "description": "Forbidden"
                     }
                 }
             }
@@ -4920,6 +4923,56 @@
                 }
             }
         },
+        "/users/me": {
+            "get": {
+                "description": "Get details of logged-in specific user",
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Retrieve logged-in user",
+                "parameters": [
+                    {
+                        "description": "Bearer Token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/response.Response"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "content": {
+                                                    "$ref": "#/components/schemas/user.Response"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "500": {
+                        "description": "Internal server error"
+                    }
+                }
+            }
+        },
         "/users/{userUUID}": {
             "get": {
                 "description": "Get details of a specific user",
@@ -6002,6 +6055,9 @@
                         "type": "string"
                     },
                     "email": {
+                        "type": "string"
+                    },
+                    "organizationUuid": {
                         "type": "string"
                     },
                     "roleId": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -57,6 +57,9 @@
                     },
                     "401": {
                         "description": "Unauthorized"
+                    },
+                    "403": {
+                        "description": "Forbidden"
                     }
                 }
             }
@@ -4697,6 +4700,56 @@
                 }
             }
         },
+        "/users/me": {
+            "get": {
+                "description": "Get details of logged-in specific user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Retrieve logged-in user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bearer Token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User details",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/response.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "content": {
+                                            "$ref": "#/definitions/user.Response"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "500": {
+                        "description": "Internal server error"
+                    }
+                }
+            }
+        },
         "/users/{userUUID}": {
             "get": {
                 "description": "Get details of a specific user",
@@ -5743,6 +5796,9 @@
                     "type": "string"
                 },
                 "email": {
+                    "type": "string"
+                },
+                "organizationUuid": {
                     "type": "string"
                 },
                 "roleId": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -602,6 +602,8 @@ definitions:
         type: string
       email:
         type: string
+      organizationUuid:
+        type: string
       roleId:
         type: integer
       status:
@@ -655,6 +657,8 @@ paths:
               type: object
         "401":
           description: Unauthorized
+        "403":
+          description: Forbidden
       summary: Check system health
       tags:
       - Admin
@@ -3688,6 +3692,36 @@ paths:
         "500":
           description: Internal server error
       summary: Logout user
+      tags:
+      - Users
+  /users/me:
+    get:
+      consumes:
+      - application/json
+      description: Get details of logged-in specific user
+      parameters:
+      - description: Bearer Token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: User details
+          schema:
+            allOf:
+            - $ref: '#/definitions/response.Response'
+            - properties:
+                content:
+                  $ref: '#/definitions/user.Response'
+              type: object
+        "401":
+          description: Unauthorized
+        "500":
+          description: Internal server error
+      summary: Retrieve logged-in user
       tags:
       - Users
 schemes:

--- a/internal/api/handlers/user.go
+++ b/internal/api/handlers/user.go
@@ -66,6 +66,37 @@ func (uh *UserHandler) Show(c echo.Context) error {
 	return response.SuccessResponse(c, mapper.ToUserResource(&fetchedUser))
 }
 
+// Me retrieves details of a logged-in user.
+//
+// @Summary Retrieve logged-in user
+// @Description Get details of logged-in specific user
+// @Tags Users
+//
+// @Accept json
+// @Produce json
+//
+// @Param Authorization header string true "Bearer Token"
+//
+// @Success 200 {object} response.Response{content=user.Response} "User details"
+// @Failure 401 "Unauthorized"
+// @Failure 500 "Internal server error"
+//
+// @Router /users/me [get]
+func (uh *UserHandler) Me(c echo.Context) error {
+	var request dto.DefaultRequest
+	if err := request.BindAndValidate(c); err != nil {
+		return response.UnprocessableResponse(c, err)
+	}
+
+	authUserUUID, _ := auth.NewAuth(c).Uuid()
+	fetchedUser, err := uh.userService.GetByUUID(authUserUUID)
+	if err != nil {
+		return response.ErrorResponse(c, err)
+	}
+
+	return response.SuccessResponse(c, mapper.ToUserResource(&fetchedUser))
+}
+
 // Login authenticates a user and returns a JWT token.
 //
 // @Summary Authenticate user

--- a/internal/api/routes/user.go
+++ b/internal/api/routes/user.go
@@ -12,6 +12,7 @@ func RegisterUserRoutes(e *echo.Echo, container *do.Injector, authMiddleware ech
 	e.POST("users/register", userController.Store)
 	e.POST("users/login", userController.Login)
 	e.GET("users/:userUUID", authMiddleware(userController.Show))
+	e.GET("users/me", authMiddleware(userController.Me))
 	e.PUT("users/:userUUID", authMiddleware(userController.Update))
 	e.POST("users/logout", authMiddleware(userController.Logout))
 }


### PR DESCRIPTION
**Why**
We had a `/users/{userUUID}` endpoint in place already. Though we were missing an endpoint for automatically fetching logged-in user's info https://github.com/fluxendd/fluxend/issues/87

**Changes**
- Adds `users/me` endpoint
- Endpoint automatically returns logged in user's response 