### PR TITLE
[🧹 chore] Documentation cleanup

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4922,9 +4922,6 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string"
-                },
-                "projectUUID": {
-                    "type": "string"
                 }
             }
         },
@@ -5025,9 +5022,6 @@ const docTemplate = `{
                         "$ref": "#/definitions/database.functionParameter"
                     }
                 },
-                "projectUUID": {
-                    "type": "string"
-                },
                 "return_type": {
                     "type": "string"
                 }
@@ -5046,9 +5040,6 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "name": {
-                    "type": "string"
-                },
-                "projectUUID": {
                     "type": "string"
                 }
             }
@@ -5081,9 +5072,6 @@ const docTemplate = `{
             "properties": {
                 "name": {
                     "type": "string"
-                },
-                "projectUUID": {
-                    "type": "string"
                 }
             }
         },
@@ -5091,9 +5079,6 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "name": {
-                    "type": "string"
-                },
-                "projectUUID": {
                     "type": "string"
                 }
             }
@@ -5141,20 +5126,12 @@ const docTemplate = `{
             }
         },
         "file.CreateRequest": {
-            "type": "object",
-            "properties": {
-                "projectUUID": {
-                    "type": "string"
-                }
-            }
+            "type": "object"
         },
         "file.RenameRequest": {
             "type": "object",
             "properties": {
                 "full_file_name": {
-                    "type": "string"
-                },
-                "projectUUID": {
                     "type": "string"
                 }
             }
@@ -5200,9 +5177,6 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/form.FieldRequest"
                     }
-                },
-                "projectUUID": {
-                    "type": "string"
                 }
             }
         },
@@ -5214,18 +5188,12 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string"
-                },
-                "projectUUID": {
-                    "type": "string"
                 }
             }
         },
         "form.CreateResponseRequest": {
             "type": "object",
             "properties": {
-                "projectUUID": {
-                    "type": "string"
-                },
                 "response": {
                     "type": "object",
                     "additionalProperties": true
@@ -5457,9 +5425,6 @@ const docTemplate = `{
                 "pattern": {
                     "type": "string"
                 },
-                "projectUUID": {
-                    "type": "string"
-                },
                 "start_date": {
                     "description": "only applicable for date types",
                     "type": "string"
@@ -5509,18 +5474,12 @@ const docTemplate = `{
             "properties": {
                 "name": {
                     "type": "string"
-                },
-                "projectUUID": {
-                    "type": "string"
                 }
             }
         },
         "organization.MemberCreateRequest": {
             "type": "object",
             "properties": {
-                "projectUUID": {
-                    "type": "string"
-                },
                 "user_id": {
                     "type": "string"
                 }
@@ -5559,9 +5518,6 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "organization_uuid": {
-                    "type": "string"
-                },
-                "projectUUID": {
                     "type": "string"
                 }
             }
@@ -5608,9 +5564,6 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "name": {
-                    "type": "string"
-                },
-                "projectUUID": {
                     "type": "string"
                 }
             }
@@ -5667,9 +5620,6 @@ const docTemplate = `{
         "setting.UpdateRequest": {
             "type": "object",
             "properties": {
-                "projectUUID": {
-                    "type": "string"
-                },
                 "settings": {
                     "type": "array",
                     "items": {
@@ -5767,9 +5717,6 @@ const docTemplate = `{
                 "password": {
                     "type": "string"
                 },
-                "projectUUID": {
-                    "type": "string"
-                },
                 "username": {
                     "type": "string"
                 }
@@ -5782,9 +5729,6 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "password": {
-                    "type": "string"
-                },
-                "projectUUID": {
                     "type": "string"
                 }
             }
@@ -5825,9 +5769,6 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "bio": {
-                    "type": "string"
-                },
-                "projectUUID": {
                     "type": "string"
                 }
             }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3187,13 +3187,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Invalid input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -5609,6 +5618,50 @@ const docTemplate = `{
                 }
             }
         },
+        "response.BadRequestErrorResponse": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "example": "null"
+                },
+                "errors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "Invalid input parameter"
+                    ]
+                },
+                "success": {
+                    "type": "boolean",
+                    "example": false
+                }
+            }
+        },
+        "response.InternalServerErrorResponse": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "example": "null"
+                },
+                "errors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "Internal server error"
+                    ]
+                },
+                "success": {
+                    "type": "boolean",
+                    "example": false
+                }
+            }
+        },
         "response.Response": {
             "type": "object",
             "properties": {
@@ -5621,6 +5674,28 @@ const docTemplate = `{
                 },
                 "success": {
                     "type": "boolean"
+                }
+            }
+        },
+        "response.UnauthorizedErrorResponse": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "example": "null"
+                },
+                "errors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "Unauthorized access"
+                    ]
+                },
+                "success": {
+                    "type": "boolean",
+                    "example": false
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4922,6 +4922,9 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
                 }
             }
         },
@@ -5022,6 +5025,9 @@ const docTemplate = `{
                         "$ref": "#/definitions/database.functionParameter"
                     }
                 },
+                "projectUUID": {
+                    "type": "string"
+                },
                 "return_type": {
                     "type": "string"
                 }
@@ -5040,6 +5046,9 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "name": {
+                    "type": "string"
+                },
+                "projectUUID": {
                     "type": "string"
                 }
             }
@@ -5072,6 +5081,9 @@ const docTemplate = `{
             "properties": {
                 "name": {
                     "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
                 }
             }
         },
@@ -5079,6 +5091,9 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "name": {
+                    "type": "string"
+                },
+                "projectUUID": {
                     "type": "string"
                 }
             }
@@ -5126,12 +5141,20 @@ const docTemplate = `{
             }
         },
         "file.CreateRequest": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
         },
         "file.RenameRequest": {
             "type": "object",
             "properties": {
                 "full_file_name": {
+                    "type": "string"
+                },
+                "projectUUID": {
                     "type": "string"
                 }
             }
@@ -5177,6 +5200,9 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/form.FieldRequest"
                     }
+                },
+                "projectUUID": {
+                    "type": "string"
                 }
             }
         },
@@ -5188,12 +5214,18 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
                 }
             }
         },
         "form.CreateResponseRequest": {
             "type": "object",
             "properties": {
+                "projectUUID": {
+                    "type": "string"
+                },
                 "response": {
                     "type": "object",
                     "additionalProperties": true
@@ -5425,6 +5457,9 @@ const docTemplate = `{
                 "pattern": {
                     "type": "string"
                 },
+                "projectUUID": {
+                    "type": "string"
+                },
                 "start_date": {
                     "description": "only applicable for date types",
                     "type": "string"
@@ -5519,6 +5554,9 @@ const docTemplate = `{
                 },
                 "organization_uuid": {
                     "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
                 }
             }
         },
@@ -5564,6 +5602,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "name": {
+                    "type": "string"
+                },
+                "projectUUID": {
                     "type": "string"
                 }
             }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -169,13 +169,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -225,13 +234,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -288,16 +306,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -347,16 +377,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -416,10 +458,16 @@ const docTemplate = `{
                         }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -480,16 +528,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -550,13 +610,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -600,13 +669,22 @@ const docTemplate = `{
                         "description": "Backup deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -690,13 +768,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -757,13 +844,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -824,13 +920,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -874,13 +979,22 @@ const docTemplate = `{
                         "description": "File deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -950,13 +1064,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -1040,13 +1163,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -1107,16 +1239,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -1177,13 +1321,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -1251,16 +1404,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -1304,13 +1469,22 @@ const docTemplate = `{
                         "description": "Form deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -1370,13 +1544,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -1437,16 +1620,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -1507,13 +1702,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -1581,16 +1785,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -1634,13 +1850,22 @@ const docTemplate = `{
                         "description": "Field deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -1704,13 +1929,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -1778,16 +2012,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -1855,13 +2101,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -1912,13 +2167,22 @@ const docTemplate = `{
                         "description": "Form response deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -1992,13 +2256,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -2059,16 +2332,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -2136,13 +2421,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -2200,13 +2494,22 @@ const docTemplate = `{
                         "description": "Form deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -2337,16 +2640,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -2400,16 +2715,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -2470,16 +2797,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -2579,16 +2918,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -2649,16 +3000,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -2704,16 +3067,28 @@ const docTemplate = `{
                         "description": "User deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -2794,13 +3169,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -2861,16 +3245,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -2924,16 +3320,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -2994,16 +3402,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -3043,13 +3463,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -3263,16 +3692,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Invalid input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -3333,16 +3774,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Invalid input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -3410,16 +3863,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -3463,13 +3928,22 @@ const docTemplate = `{
                         "description": "Container deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -3526,13 +4000,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -3593,16 +4076,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -3665,16 +4160,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -3731,13 +4238,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -3805,16 +4321,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -3882,16 +4410,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -3956,16 +4496,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -4218,16 +4770,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -4282,13 +4846,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -4347,16 +4920,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -4547,16 +5132,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -4660,13 +5257,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -4701,13 +5307,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -4811,13 +5426,22 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -4878,16 +5502,28 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -5691,6 +6327,28 @@ const docTemplate = `{
                     },
                     "example": [
                         "Unauthorized access"
+                    ]
+                },
+                "success": {
+                    "type": "boolean",
+                    "example": false
+                }
+            }
+        },
+        "response.UnprocessableErrorResponse": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "example": "null"
+                },
+                "errors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "Validation failed"
                     ]
                 },
                 "success": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -712,6 +712,13 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "description": "Project UUID",
+                        "name": "X-Project",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
                         "description": "Container UUID",
                         "name": "containerUUID",
                         "in": "path",
@@ -809,6 +816,13 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "description": "Project UUID",
+                        "name": "X-Project",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
                         "description": "Container UUID",
                         "name": "containerUUID",
                         "in": "path",
@@ -882,6 +896,13 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Bearer Token",
                         "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Project UUID",
+                        "name": "X-Project",
                         "in": "header",
                         "required": true
                     },
@@ -961,6 +982,13 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "description": "Project UUID",
+                        "name": "X-Project",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
                         "description": "Container UUID",
                         "name": "containerUUID",
                         "in": "path",
@@ -1017,6 +1045,13 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Bearer Token",
                         "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Project UUID",
+                        "name": "X-Project",
                         "in": "header",
                         "required": true
                     },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -833,6 +833,15 @@
                         }
                     },
                     {
+                        "description": "Project UUID",
+                        "name": "X-Project",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "description": "Container UUID",
                         "name": "containerUUID",
                         "in": "path",
@@ -952,6 +961,15 @@
                         }
                     },
                     {
+                        "description": "Project UUID",
+                        "name": "X-Project",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "description": "Container UUID",
                         "name": "containerUUID",
                         "in": "path",
@@ -1039,6 +1057,15 @@
                     {
                         "description": "Bearer Token",
                         "name": "Authorization",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Project UUID",
+                        "name": "X-Project",
                         "in": "header",
                         "required": true,
                         "schema": {
@@ -1136,6 +1163,15 @@
                         }
                     },
                     {
+                        "description": "Project UUID",
+                        "name": "X-Project",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "description": "Container UUID",
                         "name": "containerUUID",
                         "in": "path",
@@ -1202,6 +1238,15 @@
                     {
                         "description": "Bearer Token",
                         "name": "Authorization",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Project UUID",
+                        "name": "X-Project",
                         "in": "header",
                         "required": true,
                         "schema": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -179,13 +179,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -235,13 +256,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -300,16 +342,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -359,16 +429,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -430,10 +528,24 @@
                         }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -498,16 +610,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -572,13 +712,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -622,13 +783,34 @@
                         "description": "Backup deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -722,13 +904,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -793,13 +996,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -864,13 +1088,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -914,13 +1159,34 @@
                         "description": "File deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -996,13 +1262,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1096,13 +1383,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -1159,16 +1467,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1233,13 +1569,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -1305,16 +1662,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -1358,13 +1743,34 @@
                         "description": "Form deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1426,13 +1832,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -1497,16 +1924,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1571,13 +2026,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -1651,16 +2127,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -1704,13 +2208,34 @@
                         "description": "Field deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1778,13 +2303,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -1858,16 +2404,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1941,13 +2515,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -2000,13 +2595,34 @@
                         "description": "Form response deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -2086,13 +2702,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -2157,16 +2794,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -2240,13 +2905,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -2308,13 +2994,34 @@
                         "description": "Form deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -2455,16 +3162,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -2520,16 +3255,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -2594,16 +3357,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -2707,16 +3498,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -2781,16 +3600,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -2836,16 +3683,44 @@
                         "description": "User deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -2936,13 +3811,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -3007,16 +3903,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -3072,16 +3996,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -3146,16 +4098,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -3197,13 +4177,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -3353,13 +4354,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Invalid input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -3416,16 +4438,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Invalid input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -3490,16 +4540,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Invalid input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -3565,16 +4643,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -3618,13 +4724,34 @@
                         "description": "Container deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -3683,13 +4810,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -3754,16 +4902,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -3830,16 +5006,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -3898,13 +5102,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -3978,16 +5203,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -4061,16 +5314,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -4143,16 +5424,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -4417,16 +5726,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -4483,13 +5820,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -4552,16 +5910,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -4762,16 +6148,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -4871,13 +6285,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -4912,13 +6347,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -5024,13 +6480,34 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -5095,16 +6572,44 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.BadRequestErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnauthorizedErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.UnprocessableErrorResponse"
+                                }
+                            }
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response.InternalServerErrorResponse"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -5865,6 +7370,50 @@
                     }
                 }
             },
+            "response.BadRequestErrorResponse": {
+                "type": "object",
+                "properties": {
+                    "content": {
+                        "type": "string",
+                        "example": "null"
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "example": [
+                            "Invalid input parameter"
+                        ]
+                    },
+                    "success": {
+                        "type": "boolean",
+                        "example": false
+                    }
+                }
+            },
+            "response.InternalServerErrorResponse": {
+                "type": "object",
+                "properties": {
+                    "content": {
+                        "type": "string",
+                        "example": "null"
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "example": [
+                            "Internal server error"
+                        ]
+                    },
+                    "success": {
+                        "type": "boolean",
+                        "example": false
+                    }
+                }
+            },
             "response.Response": {
                 "type": "object",
                 "properties": {
@@ -5877,6 +7426,50 @@
                     },
                     "success": {
                         "type": "boolean"
+                    }
+                }
+            },
+            "response.UnauthorizedErrorResponse": {
+                "type": "object",
+                "properties": {
+                    "content": {
+                        "type": "string",
+                        "example": "null"
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "example": [
+                            "Unauthorized access"
+                        ]
+                    },
+                    "success": {
+                        "type": "boolean",
+                        "example": false
+                    }
+                }
+            },
+            "response.UnprocessableErrorResponse": {
+                "type": "object",
+                "properties": {
+                    "content": {
+                        "type": "string",
+                        "example": "null"
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "example": [
+                            "Validation failed"
+                        ]
+                    },
+                    "success": {
+                        "type": "boolean",
+                        "example": false
                     }
                 }
             },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5178,9 +5178,6 @@
                     },
                     "name": {
                         "type": "string"
-                    },
-                    "projectUUID": {
-                        "type": "string"
                     }
                 }
             },
@@ -5281,9 +5278,6 @@
                             "$ref": "#/components/schemas/database.functionParameter"
                         }
                     },
-                    "projectUUID": {
-                        "type": "string"
-                    },
                     "return_type": {
                         "type": "string"
                     }
@@ -5302,9 +5296,6 @@
                         "type": "boolean"
                     },
                     "name": {
-                        "type": "string"
-                    },
-                    "projectUUID": {
                         "type": "string"
                     }
                 }
@@ -5337,9 +5328,6 @@
                 "properties": {
                     "name": {
                         "type": "string"
-                    },
-                    "projectUUID": {
-                        "type": "string"
                     }
                 }
             },
@@ -5347,9 +5335,6 @@
                 "type": "object",
                 "properties": {
                     "name": {
-                        "type": "string"
-                    },
-                    "projectUUID": {
                         "type": "string"
                     }
                 }
@@ -5397,20 +5382,12 @@
                 }
             },
             "file.CreateRequest": {
-                "type": "object",
-                "properties": {
-                    "projectUUID": {
-                        "type": "string"
-                    }
-                }
+                "type": "object"
             },
             "file.RenameRequest": {
                 "type": "object",
                 "properties": {
                     "full_file_name": {
-                        "type": "string"
-                    },
-                    "projectUUID": {
                         "type": "string"
                     }
                 }
@@ -5456,9 +5433,6 @@
                         "items": {
                             "$ref": "#/components/schemas/form.FieldRequest"
                         }
-                    },
-                    "projectUUID": {
-                        "type": "string"
                     }
                 }
             },
@@ -5470,18 +5444,12 @@
                     },
                     "name": {
                         "type": "string"
-                    },
-                    "projectUUID": {
-                        "type": "string"
                     }
                 }
             },
             "form.CreateResponseRequest": {
                 "type": "object",
                 "properties": {
-                    "projectUUID": {
-                        "type": "string"
-                    },
                     "response": {
                         "type": "object",
                         "additionalProperties": true
@@ -5713,9 +5681,6 @@
                     "pattern": {
                         "type": "string"
                     },
-                    "projectUUID": {
-                        "type": "string"
-                    },
                     "start_date": {
                         "description": "only applicable for date types",
                         "type": "string"
@@ -5765,18 +5730,12 @@
                 "properties": {
                     "name": {
                         "type": "string"
-                    },
-                    "projectUUID": {
-                        "type": "string"
                     }
                 }
             },
             "organization.MemberCreateRequest": {
                 "type": "object",
                 "properties": {
-                    "projectUUID": {
-                        "type": "string"
-                    },
                     "user_id": {
                         "type": "string"
                     }
@@ -5815,9 +5774,6 @@
                         "type": "string"
                     },
                     "organization_uuid": {
-                        "type": "string"
-                    },
-                    "projectUUID": {
                         "type": "string"
                     }
                 }
@@ -5864,9 +5820,6 @@
                         "type": "string"
                     },
                     "name": {
-                        "type": "string"
-                    },
-                    "projectUUID": {
                         "type": "string"
                     }
                 }
@@ -5923,9 +5876,6 @@
             "setting.UpdateRequest": {
                 "type": "object",
                 "properties": {
-                    "projectUUID": {
-                        "type": "string"
-                    },
                     "settings": {
                         "type": "array",
                         "items": {
@@ -6023,9 +5973,6 @@
                     "password": {
                         "type": "string"
                     },
-                    "projectUUID": {
-                        "type": "string"
-                    },
                     "username": {
                         "type": "string"
                     }
@@ -6038,9 +5985,6 @@
                         "type": "string"
                     },
                     "password": {
-                        "type": "string"
-                    },
-                    "projectUUID": {
                         "type": "string"
                     }
                 }
@@ -6081,9 +6025,6 @@
                 "type": "object",
                 "properties": {
                     "bio": {
-                        "type": "string"
-                    },
-                    "projectUUID": {
                         "type": "string"
                     }
                 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5178,6 +5178,9 @@
                     },
                     "name": {
                         "type": "string"
+                    },
+                    "projectUUID": {
+                        "type": "string"
                     }
                 }
             },
@@ -5278,6 +5281,9 @@
                             "$ref": "#/components/schemas/database.functionParameter"
                         }
                     },
+                    "projectUUID": {
+                        "type": "string"
+                    },
                     "return_type": {
                         "type": "string"
                     }
@@ -5296,6 +5302,9 @@
                         "type": "boolean"
                     },
                     "name": {
+                        "type": "string"
+                    },
+                    "projectUUID": {
                         "type": "string"
                     }
                 }
@@ -5328,6 +5337,9 @@
                 "properties": {
                     "name": {
                         "type": "string"
+                    },
+                    "projectUUID": {
+                        "type": "string"
                     }
                 }
             },
@@ -5335,6 +5347,9 @@
                 "type": "object",
                 "properties": {
                     "name": {
+                        "type": "string"
+                    },
+                    "projectUUID": {
                         "type": "string"
                     }
                 }
@@ -5382,12 +5397,20 @@
                 }
             },
             "file.CreateRequest": {
-                "type": "object"
+                "type": "object",
+                "properties": {
+                    "projectUUID": {
+                        "type": "string"
+                    }
+                }
             },
             "file.RenameRequest": {
                 "type": "object",
                 "properties": {
                     "full_file_name": {
+                        "type": "string"
+                    },
+                    "projectUUID": {
                         "type": "string"
                     }
                 }
@@ -5433,6 +5456,9 @@
                         "items": {
                             "$ref": "#/components/schemas/form.FieldRequest"
                         }
+                    },
+                    "projectUUID": {
+                        "type": "string"
                     }
                 }
             },
@@ -5444,12 +5470,18 @@
                     },
                     "name": {
                         "type": "string"
+                    },
+                    "projectUUID": {
+                        "type": "string"
                     }
                 }
             },
             "form.CreateResponseRequest": {
                 "type": "object",
                 "properties": {
+                    "projectUUID": {
+                        "type": "string"
+                    },
                     "response": {
                         "type": "object",
                         "additionalProperties": true
@@ -5681,6 +5713,9 @@
                     "pattern": {
                         "type": "string"
                     },
+                    "projectUUID": {
+                        "type": "string"
+                    },
                     "start_date": {
                         "description": "only applicable for date types",
                         "type": "string"
@@ -5775,6 +5810,9 @@
                     },
                     "organization_uuid": {
                         "type": "string"
+                    },
+                    "projectUUID": {
+                        "type": "string"
                     }
                 }
             },
@@ -5820,6 +5858,9 @@
                         "type": "string"
                     },
                     "name": {
+                        "type": "string"
+                    },
+                    "projectUUID": {
                         "type": "string"
                     }
                 }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -166,13 +166,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -222,13 +231,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -285,16 +303,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -344,16 +374,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -413,10 +455,16 @@
                         }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -477,16 +525,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -547,13 +607,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -597,13 +666,22 @@
                         "description": "Backup deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -687,13 +765,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -754,13 +841,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -821,13 +917,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -871,13 +976,22 @@
                         "description": "File deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -947,13 +1061,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -1037,13 +1160,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -1104,16 +1236,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -1174,13 +1318,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -1248,16 +1401,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -1301,13 +1466,22 @@
                         "description": "Form deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -1367,13 +1541,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -1434,16 +1617,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -1504,13 +1699,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -1578,16 +1782,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -1631,13 +1847,22 @@
                         "description": "Field deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -1701,13 +1926,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -1775,16 +2009,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -1852,13 +2098,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -1909,13 +2164,22 @@
                         "description": "Form response deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -1989,13 +2253,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -2056,16 +2329,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -2133,13 +2418,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -2197,13 +2491,22 @@
                         "description": "Form deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -2334,16 +2637,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -2397,16 +2712,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -2467,16 +2794,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -2576,16 +2915,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -2646,16 +2997,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -2701,16 +3064,28 @@
                         "description": "User deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -2791,13 +3166,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -2858,16 +3242,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -2921,16 +3317,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -2991,16 +3399,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -3040,13 +3460,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -3184,13 +3613,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Invalid input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -3251,16 +3689,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Invalid input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -3321,16 +3771,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Invalid input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -3398,16 +3860,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -3451,13 +3925,22 @@
                         "description": "Container deleted"
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -3514,13 +3997,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -3581,16 +4073,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -3653,16 +4157,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -3719,13 +4235,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -3793,16 +4318,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -3870,16 +4407,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -3944,16 +4493,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -4206,16 +4767,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -4270,13 +4843,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -4335,16 +4917,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -4535,16 +5129,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -4648,13 +5254,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -4689,13 +5304,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -4799,13 +5423,22 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             },
@@ -4866,16 +5499,28 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid input"
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
                     },
                     "401": {
-                        "description": "Unauthorized"
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
                     },
                     "422": {
-                        "description": "Unprocessable entity"
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
                     },
                     "500": {
-                        "description": "Internal server error"
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
                     }
                 }
             }
@@ -5606,6 +6251,50 @@
                 }
             }
         },
+        "response.BadRequestErrorResponse": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "example": "null"
+                },
+                "errors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "Invalid input parameter"
+                    ]
+                },
+                "success": {
+                    "type": "boolean",
+                    "example": false
+                }
+            }
+        },
+        "response.InternalServerErrorResponse": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "example": "null"
+                },
+                "errors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "Internal server error"
+                    ]
+                },
+                "success": {
+                    "type": "boolean",
+                    "example": false
+                }
+            }
+        },
         "response.Response": {
             "type": "object",
             "properties": {
@@ -5618,6 +6307,50 @@
                 },
                 "success": {
                     "type": "boolean"
+                }
+            }
+        },
+        "response.UnauthorizedErrorResponse": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "example": "null"
+                },
+                "errors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "Unauthorized access"
+                    ]
+                },
+                "success": {
+                    "type": "boolean",
+                    "example": false
+                }
+            }
+        },
+        "response.UnprocessableErrorResponse": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "example": "null"
+                },
+                "errors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "Validation failed"
+                    ]
+                },
+                "success": {
+                    "type": "boolean",
+                    "example": false
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4919,6 +4919,9 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
                 }
             }
         },
@@ -5019,6 +5022,9 @@
                         "$ref": "#/definitions/database.functionParameter"
                     }
                 },
+                "projectUUID": {
+                    "type": "string"
+                },
                 "return_type": {
                     "type": "string"
                 }
@@ -5037,6 +5043,9 @@
                     "type": "boolean"
                 },
                 "name": {
+                    "type": "string"
+                },
+                "projectUUID": {
                     "type": "string"
                 }
             }
@@ -5069,6 +5078,9 @@
             "properties": {
                 "name": {
                     "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
                 }
             }
         },
@@ -5076,6 +5088,9 @@
             "type": "object",
             "properties": {
                 "name": {
+                    "type": "string"
+                },
+                "projectUUID": {
                     "type": "string"
                 }
             }
@@ -5123,12 +5138,20 @@
             }
         },
         "file.CreateRequest": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
         },
         "file.RenameRequest": {
             "type": "object",
             "properties": {
                 "full_file_name": {
+                    "type": "string"
+                },
+                "projectUUID": {
                     "type": "string"
                 }
             }
@@ -5174,6 +5197,9 @@
                     "items": {
                         "$ref": "#/definitions/form.FieldRequest"
                     }
+                },
+                "projectUUID": {
+                    "type": "string"
                 }
             }
         },
@@ -5185,12 +5211,18 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
                 }
             }
         },
         "form.CreateResponseRequest": {
             "type": "object",
             "properties": {
+                "projectUUID": {
+                    "type": "string"
+                },
                 "response": {
                     "type": "object",
                     "additionalProperties": true
@@ -5422,6 +5454,9 @@
                 "pattern": {
                     "type": "string"
                 },
+                "projectUUID": {
+                    "type": "string"
+                },
                 "start_date": {
                     "description": "only applicable for date types",
                     "type": "string"
@@ -5516,6 +5551,9 @@
                 },
                 "organization_uuid": {
                     "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
                 }
             }
         },
@@ -5561,6 +5599,9 @@
                     "type": "string"
                 },
                 "name": {
+                    "type": "string"
+                },
+                "projectUUID": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -709,6 +709,13 @@
                     },
                     {
                         "type": "string",
+                        "description": "Project UUID",
+                        "name": "X-Project",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
                         "description": "Container UUID",
                         "name": "containerUUID",
                         "in": "path",
@@ -806,6 +813,13 @@
                     },
                     {
                         "type": "string",
+                        "description": "Project UUID",
+                        "name": "X-Project",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
                         "description": "Container UUID",
                         "name": "containerUUID",
                         "in": "path",
@@ -879,6 +893,13 @@
                         "type": "string",
                         "description": "Bearer Token",
                         "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Project UUID",
+                        "name": "X-Project",
                         "in": "header",
                         "required": true
                     },
@@ -958,6 +979,13 @@
                     },
                     {
                         "type": "string",
+                        "description": "Project UUID",
+                        "name": "X-Project",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
                         "description": "Container UUID",
                         "name": "containerUUID",
                         "in": "path",
@@ -1014,6 +1042,13 @@
                         "type": "string",
                         "description": "Bearer Token",
                         "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Project UUID",
+                        "name": "X-Project",
                         "in": "header",
                         "required": true
                     },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4919,9 +4919,6 @@
                 },
                 "name": {
                     "type": "string"
-                },
-                "projectUUID": {
-                    "type": "string"
                 }
             }
         },
@@ -5022,9 +5019,6 @@
                         "$ref": "#/definitions/database.functionParameter"
                     }
                 },
-                "projectUUID": {
-                    "type": "string"
-                },
                 "return_type": {
                     "type": "string"
                 }
@@ -5043,9 +5037,6 @@
                     "type": "boolean"
                 },
                 "name": {
-                    "type": "string"
-                },
-                "projectUUID": {
                     "type": "string"
                 }
             }
@@ -5078,9 +5069,6 @@
             "properties": {
                 "name": {
                     "type": "string"
-                },
-                "projectUUID": {
-                    "type": "string"
                 }
             }
         },
@@ -5088,9 +5076,6 @@
             "type": "object",
             "properties": {
                 "name": {
-                    "type": "string"
-                },
-                "projectUUID": {
                     "type": "string"
                 }
             }
@@ -5138,20 +5123,12 @@
             }
         },
         "file.CreateRequest": {
-            "type": "object",
-            "properties": {
-                "projectUUID": {
-                    "type": "string"
-                }
-            }
+            "type": "object"
         },
         "file.RenameRequest": {
             "type": "object",
             "properties": {
                 "full_file_name": {
-                    "type": "string"
-                },
-                "projectUUID": {
                     "type": "string"
                 }
             }
@@ -5197,9 +5174,6 @@
                     "items": {
                         "$ref": "#/definitions/form.FieldRequest"
                     }
-                },
-                "projectUUID": {
-                    "type": "string"
                 }
             }
         },
@@ -5211,18 +5185,12 @@
                 },
                 "name": {
                     "type": "string"
-                },
-                "projectUUID": {
-                    "type": "string"
                 }
             }
         },
         "form.CreateResponseRequest": {
             "type": "object",
             "properties": {
-                "projectUUID": {
-                    "type": "string"
-                },
                 "response": {
                     "type": "object",
                     "additionalProperties": true
@@ -5454,9 +5422,6 @@
                 "pattern": {
                     "type": "string"
                 },
-                "projectUUID": {
-                    "type": "string"
-                },
                 "start_date": {
                     "description": "only applicable for date types",
                     "type": "string"
@@ -5506,18 +5471,12 @@
             "properties": {
                 "name": {
                     "type": "string"
-                },
-                "projectUUID": {
-                    "type": "string"
                 }
             }
         },
         "organization.MemberCreateRequest": {
             "type": "object",
             "properties": {
-                "projectUUID": {
-                    "type": "string"
-                },
                 "user_id": {
                     "type": "string"
                 }
@@ -5556,9 +5515,6 @@
                     "type": "string"
                 },
                 "organization_uuid": {
-                    "type": "string"
-                },
-                "projectUUID": {
                     "type": "string"
                 }
             }
@@ -5605,9 +5561,6 @@
                     "type": "string"
                 },
                 "name": {
-                    "type": "string"
-                },
-                "projectUUID": {
                     "type": "string"
                 }
             }
@@ -5664,9 +5617,6 @@
         "setting.UpdateRequest": {
             "type": "object",
             "properties": {
-                "projectUUID": {
-                    "type": "string"
-                },
                 "settings": {
                     "type": "array",
                     "items": {
@@ -5764,9 +5714,6 @@
                 "password": {
                     "type": "string"
                 },
-                "projectUUID": {
-                    "type": "string"
-                },
                 "username": {
                     "type": "string"
                 }
@@ -5779,9 +5726,6 @@
                     "type": "string"
                 },
                 "password": {
-                    "type": "string"
-                },
-                "projectUUID": {
                     "type": "string"
                 }
             }
@@ -5822,9 +5766,6 @@
             "type": "object",
             "properties": {
                 "bio": {
-                    "type": "string"
-                },
-                "projectUUID": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1115,6 +1115,11 @@ paths:
         name: Authorization
         required: true
         type: string
+      - description: Project UUID
+        in: header
+        name: X-Project
+        required: true
+        type: string
       - description: Container UUID
         in: path
         name: containerUUID
@@ -1177,6 +1182,11 @@ paths:
         name: Authorization
         required: true
         type: string
+      - description: Project UUID
+        in: header
+        name: X-Project
+        required: true
+        type: string
       - description: Container UUID
         in: path
         name: containerUUID
@@ -1226,6 +1236,11 @@ paths:
         name: Authorization
         required: true
         type: string
+      - description: Project UUID
+        in: header
+        name: X-Project
+        required: true
+        type: string
       - description: Container UUID
         in: path
         name: containerUUID
@@ -1264,6 +1279,11 @@ paths:
       - description: Bearer Token
         in: header
         name: Authorization
+        required: true
+        type: string
+      - description: Project UUID
+        in: header
+        name: X-Project
         required: true
         type: string
       - description: Container UUID
@@ -1313,6 +1333,11 @@ paths:
       - description: Bearer Token
         in: header
         name: Authorization
+        required: true
+        type: string
+      - description: Project UUID
+        in: header
+        name: X-Project
         required: true
         type: string
       - description: Container UUID

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -25,8 +25,6 @@ definitions:
         type: integer
       name:
         type: string
-      projectUUID:
-        type: string
     type: object
   container.Response:
     properties:
@@ -92,8 +90,6 @@ definitions:
         items:
           $ref: '#/definitions/database.functionParameter'
         type: array
-      projectUUID:
-        type: string
       return_type:
         type: string
     type: object
@@ -106,8 +102,6 @@ definitions:
       is_unique:
         type: boolean
       name:
-        type: string
-      projectUUID:
         type: string
     type: object
   database.CreateTableRequest:
@@ -129,14 +123,10 @@ definitions:
     properties:
       name:
         type: string
-      projectUUID:
-        type: string
     type: object
   database.RenameTableRequest:
     properties:
       name:
-        type: string
-      projectUUID:
         type: string
     type: object
   database.TableResponse:
@@ -167,15 +157,10 @@ definitions:
         type: string
     type: object
   file.CreateRequest:
-    properties:
-      projectUUID:
-        type: string
     type: object
   file.RenameRequest:
     properties:
       full_file_name:
-        type: string
-      projectUUID:
         type: string
     type: object
   file.Response:
@@ -206,8 +191,6 @@ definitions:
         items:
           $ref: '#/definitions/form.FieldRequest'
         type: array
-      projectUUID:
-        type: string
     type: object
   form.CreateRequest:
     properties:
@@ -215,13 +198,9 @@ definitions:
         type: string
       name:
         type: string
-      projectUUID:
-        type: string
     type: object
   form.CreateResponseRequest:
     properties:
-      projectUUID:
-        type: string
       response:
         additionalProperties: true
         type: object
@@ -378,8 +357,6 @@ definitions:
         type: string
       pattern:
         type: string
-      projectUUID:
-        type: string
       start_date:
         description: only applicable for date types
         type: string
@@ -413,13 +390,9 @@ definitions:
     properties:
       name:
         type: string
-      projectUUID:
-        type: string
     type: object
   organization.MemberCreateRequest:
     properties:
-      projectUUID:
-        type: string
       user_id:
         type: string
     type: object
@@ -445,8 +418,6 @@ definitions:
       name:
         type: string
       organization_uuid:
-        type: string
-      projectUUID:
         type: string
     type: object
   project.Response:
@@ -477,8 +448,6 @@ definitions:
       description:
         type: string
       name:
-        type: string
-      projectUUID:
         type: string
     type: object
   response.Response:
@@ -515,8 +484,6 @@ definitions:
     type: object
   setting.UpdateRequest:
     properties:
-      projectUUID:
-        type: string
       settings:
         items:
           $ref: '#/definitions/setting.IndividualSetting'
@@ -580,8 +547,6 @@ definitions:
         type: string
       password:
         type: string
-      projectUUID:
-        type: string
       username:
         type: string
     type: object
@@ -590,8 +555,6 @@ definitions:
       email:
         type: string
       password:
-        type: string
-      projectUUID:
         type: string
     type: object
   user.Response:
@@ -618,8 +581,6 @@ definitions:
   user.UpdateRequest:
     properties:
       bio:
-        type: string
-      projectUUID:
         type: string
     type: object
 host: api.fluxend.app

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -25,6 +25,8 @@ definitions:
         type: integer
       name:
         type: string
+      projectUUID:
+        type: string
     type: object
   container.Response:
     properties:
@@ -90,6 +92,8 @@ definitions:
         items:
           $ref: '#/definitions/database.functionParameter'
         type: array
+      projectUUID:
+        type: string
       return_type:
         type: string
     type: object
@@ -102,6 +106,8 @@ definitions:
       is_unique:
         type: boolean
       name:
+        type: string
+      projectUUID:
         type: string
     type: object
   database.CreateTableRequest:
@@ -123,10 +129,14 @@ definitions:
     properties:
       name:
         type: string
+      projectUUID:
+        type: string
     type: object
   database.RenameTableRequest:
     properties:
       name:
+        type: string
+      projectUUID:
         type: string
     type: object
   database.TableResponse:
@@ -157,10 +167,15 @@ definitions:
         type: string
     type: object
   file.CreateRequest:
+    properties:
+      projectUUID:
+        type: string
     type: object
   file.RenameRequest:
     properties:
       full_file_name:
+        type: string
+      projectUUID:
         type: string
     type: object
   file.Response:
@@ -191,6 +206,8 @@ definitions:
         items:
           $ref: '#/definitions/form.FieldRequest'
         type: array
+      projectUUID:
+        type: string
     type: object
   form.CreateRequest:
     properties:
@@ -198,9 +215,13 @@ definitions:
         type: string
       name:
         type: string
+      projectUUID:
+        type: string
     type: object
   form.CreateResponseRequest:
     properties:
+      projectUUID:
+        type: string
       response:
         additionalProperties: true
         type: object
@@ -357,6 +378,8 @@ definitions:
         type: string
       pattern:
         type: string
+      projectUUID:
+        type: string
       start_date:
         description: only applicable for date types
         type: string
@@ -419,6 +442,8 @@ definitions:
         type: string
       organization_uuid:
         type: string
+      projectUUID:
+        type: string
     type: object
   project.Response:
     properties:
@@ -448,6 +473,8 @@ definitions:
       description:
         type: string
       name:
+        type: string
+      projectUUID:
         type: string
     type: object
   response.Response:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -477,6 +477,36 @@ definitions:
       projectUUID:
         type: string
     type: object
+  response.BadRequestErrorResponse:
+    properties:
+      content:
+        example: "null"
+        type: string
+      errors:
+        example:
+        - Invalid input parameter
+        items:
+          type: string
+        type: array
+      success:
+        example: false
+        type: boolean
+    type: object
+  response.InternalServerErrorResponse:
+    properties:
+      content:
+        example: "null"
+        type: string
+      errors:
+        example:
+        - Internal server error
+        items:
+          type: string
+        type: array
+      success:
+        example: false
+        type: boolean
+    type: object
   response.Response:
     properties:
       content: {}
@@ -485,6 +515,36 @@ definitions:
           type: string
         type: array
       success:
+        type: boolean
+    type: object
+  response.UnauthorizedErrorResponse:
+    properties:
+      content:
+        example: "null"
+        type: string
+      errors:
+        example:
+        - Unauthorized access
+        items:
+          type: string
+        type: array
+      success:
+        example: false
+        type: boolean
+    type: object
+  response.UnprocessableErrorResponse:
+    properties:
+      content:
+        example: "null"
+        type: string
+      errors:
+        example:
+        - Validation failed
+        items:
+          type: string
+        type: array
+      success:
+        example: false
         type: boolean
     type: object
   setting.IndividualSetting:
@@ -714,11 +774,17 @@ paths:
                 type: object
             type: array
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: List logs
       tags:
       - Logs
@@ -748,11 +814,17 @@ paths:
                   type: array
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: List settings
       tags:
       - Admin
@@ -787,13 +859,21 @@ paths:
                   type: array
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Update settings
       tags:
       - Admin
@@ -823,13 +903,21 @@ paths:
                   type: array
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Reset settings
       tags:
       - Admin
@@ -866,9 +954,13 @@ paths:
                 type: object
             type: array
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: List backups
       tags:
       - Backups
@@ -906,13 +998,21 @@ paths:
                   $ref: '#/definitions/backup.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Create backup
       tags:
       - Backups
@@ -943,11 +1043,17 @@ paths:
         "204":
           description: Backup deleted
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Delete backup
       tags:
       - Backups
@@ -984,11 +1090,17 @@ paths:
                   $ref: '#/definitions/backup.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Retrieve backup
       tags:
       - Backups
@@ -1041,11 +1153,17 @@ paths:
                 type: object
             type: array
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: List files
       tags:
       - Files
@@ -1083,11 +1201,17 @@ paths:
                   $ref: '#/definitions/file.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Create file
       tags:
       - Files
@@ -1118,11 +1242,17 @@ paths:
         "204":
           description: File deleted
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Delete file
       tags:
       - Files
@@ -1159,11 +1289,17 @@ paths:
                   $ref: '#/definitions/file.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Retrieve file
       tags:
       - Files
@@ -1208,11 +1344,17 @@ paths:
                   $ref: '#/definitions/file.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Rename file
       tags:
       - Files
@@ -1265,11 +1407,17 @@ paths:
                 type: object
             type: array
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: List forms
       tags:
       - Forms
@@ -1307,13 +1455,21 @@ paths:
                   $ref: '#/definitions/form.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Create form
       tags:
       - Forms
@@ -1344,11 +1500,17 @@ paths:
         "204":
           description: Form deleted
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Delete form
       tags:
       - Forms
@@ -1385,11 +1547,17 @@ paths:
                   $ref: '#/definitions/form.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Retrieve form
       tags:
       - Forms
@@ -1432,13 +1600,21 @@ paths:
                   $ref: '#/definitions/form.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Update form
       tags:
       - Forms
@@ -1475,11 +1651,17 @@ paths:
                 type: object
             type: array
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: List fields
       tags:
       - Form Fields
@@ -1517,13 +1699,21 @@ paths:
                   $ref: '#/definitions/form.FieldResponseApi'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Create field
       tags:
       - Form Fields
@@ -1554,11 +1744,17 @@ paths:
         "204":
           description: Field deleted
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Delete field
       tags:
       - Form Fields
@@ -1595,11 +1791,17 @@ paths:
                   $ref: '#/definitions/form.FieldResponseApi'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Retrieve field
       tags:
       - Form Fields
@@ -1642,13 +1844,21 @@ paths:
                   $ref: '#/definitions/form.FieldResponseApi'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Update field
       tags:
       - Form Fields
@@ -1688,11 +1898,17 @@ paths:
                   type: array
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: List form responses
       tags:
       - Form Responses
@@ -1735,13 +1951,21 @@ paths:
                   $ref: '#/definitions/form.ResponseForAPI'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Create form response
       tags:
       - Form Responses
@@ -1777,11 +2001,17 @@ paths:
         "204":
           description: Form response deleted
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Delete form response
       tags:
       - Form Responses
@@ -1823,11 +2053,17 @@ paths:
                   $ref: '#/definitions/form.ResponseForAPI'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Retrieve form response
       tags:
       - Form Responses
@@ -1874,11 +2110,17 @@ paths:
                 type: object
             type: array
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: List functions
       tags:
       - Functions
@@ -1916,13 +2158,21 @@ paths:
                   $ref: '#/definitions/database.FunctionResponse'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Create function
       tags:
       - Functions
@@ -1963,11 +2213,17 @@ paths:
         "204":
           description: Form deleted
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Delete function
       tags:
       - Functions
@@ -2009,11 +2265,17 @@ paths:
                   $ref: '#/definitions/database.FunctionResponse'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Retrieve function
       tags:
       - Functions
@@ -2094,13 +2356,21 @@ paths:
                   $ref: '#/definitions/organization.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Create organization
       tags:
       - Organizations
@@ -2162,13 +2432,21 @@ paths:
                   $ref: '#/definitions/organization.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Retrieve organization
       tags:
       - Organizations
@@ -2206,13 +2484,21 @@ paths:
                   $ref: '#/definitions/organization.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Update organization
       tags:
       - Organizations
@@ -2247,13 +2533,21 @@ paths:
                   type: array
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: List organization members
       tags:
       - Organization Members
@@ -2291,13 +2585,21 @@ paths:
                   $ref: '#/definitions/user.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Create organization member
       tags:
       - Organization Members
@@ -2328,13 +2630,21 @@ paths:
         "204":
           description: User deleted
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Delete organization member
       tags:
       - Organization Members
@@ -2385,11 +2695,17 @@ paths:
                   type: array
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: List projects
       tags:
       - Projects
@@ -2427,13 +2743,21 @@ paths:
                   $ref: '#/definitions/project.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Create project
       tags:
       - Projects
@@ -2461,11 +2785,17 @@ paths:
           schema:
             $ref: '#/definitions/response.Response'
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Delete project
       tags:
       - Projects
@@ -2497,13 +2827,21 @@ paths:
                   $ref: '#/definitions/project.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Retrieve project
       tags:
       - Projects
@@ -2541,13 +2879,21 @@ paths:
                   $ref: '#/definitions/project.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Update project
       tags:
       - Projects
@@ -2633,11 +2979,17 @@ paths:
                   type: array
               type: object
         "400":
-          description: Invalid input
+          description: Invalid input response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: List containers
       tags:
       - Containers
@@ -2675,13 +3027,21 @@ paths:
                   $ref: '#/definitions/container.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Invalid input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Create container
       tags:
       - Containers
@@ -2712,11 +3072,17 @@ paths:
         "204":
           description: Container deleted
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Delete container
       tags:
       - Containers
@@ -2753,13 +3119,21 @@ paths:
                   $ref: '#/definitions/container.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Invalid input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Retrieve container
       tags:
       - Containers
@@ -2802,13 +3176,21 @@ paths:
                   $ref: '#/definitions/container.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Update container
       tags:
       - Containers
@@ -2843,11 +3225,17 @@ paths:
                   type: array
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: List tables
       tags:
       - Tables
@@ -2885,13 +3273,21 @@ paths:
                   $ref: '#/definitions/database.TableResponse'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Create table
       tags:
       - Tables
@@ -2926,11 +3322,17 @@ paths:
                   type: array
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: List columns
       tags:
       - Columns
@@ -2973,13 +3375,21 @@ paths:
                   $ref: '#/definitions/database.ColumnResponse'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Create column
       tags:
       - Columns
@@ -3022,13 +3432,21 @@ paths:
                   $ref: '#/definitions/database.ColumnResponse'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Modify columns
       tags:
       - Columns
@@ -3113,13 +3531,21 @@ paths:
           schema:
             $ref: '#/definitions/response.Response'
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Rename column
       tags:
       - Columns
@@ -3243,13 +3669,21 @@ paths:
                   $ref: '#/definitions/database.TableResponse'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Duplicate table
       tags:
       - Tables
@@ -3283,11 +3717,17 @@ paths:
                   type: array
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: List indexes
       tags:
       - Indexes
@@ -3324,13 +3764,21 @@ paths:
                 content: {}
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Create index
       tags:
       - Indexes
@@ -3453,13 +3901,21 @@ paths:
                   $ref: '#/definitions/database.TableResponse'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Rename table
       tags:
       - Tables
@@ -3498,13 +3954,21 @@ paths:
                   $ref: '#/definitions/database.TableResponse'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Upload table
       tags:
       - Tables
@@ -3570,11 +4034,17 @@ paths:
                   $ref: '#/definitions/user.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Retrieve user
       tags:
       - Users
@@ -3612,13 +4082,21 @@ paths:
                   $ref: '#/definitions/user.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "422":
-          description: Unprocessable entity
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Update user
       tags:
       - Users
@@ -3647,11 +4125,17 @@ paths:
                   $ref: '#/definitions/user.Response'
               type: object
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Authenticate user
       tags:
       - Users
@@ -3674,11 +4158,17 @@ paths:
           schema:
             $ref: '#/definitions/response.Response'
         "400":
-          description: Invalid input
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
         "401":
-          description: Unauthorized
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
         "500":
-          description: Internal server error
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Logout user
       tags:
       - Users

--- a/internal/api/dto/base_project_request.go
+++ b/internal/api/dto/base_project_request.go
@@ -1,11 +1,14 @@
 package dto
 
 import (
+	"errors"
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 )
 
 type DefaultRequestWithProjectHeader struct {
 	BaseRequest
+	ProjectUUID uuid.UUID `json:"projectUUID"`
 }
 
 func (r *DefaultRequestWithProjectHeader) BindAndValidate(c echo.Context) []string {
@@ -17,6 +20,17 @@ func (r *DefaultRequestWithProjectHeader) BindAndValidate(c echo.Context) []stri
 	if err != nil {
 		return []string{err.Error()}
 	}
+
+	return nil
+}
+
+func (r *DefaultRequestWithProjectHeader) WithProjectHeader(c echo.Context) error {
+	projectUUID, err := uuid.Parse(c.Request().Header.Get("X-Project"))
+	if err != nil {
+		return errors.New("invalid project UUID")
+	}
+
+	r.ProjectUUID = projectUUID
 
 	return nil
 }

--- a/internal/api/dto/base_request.go
+++ b/internal/api/dto/base_request.go
@@ -1,7 +1,6 @@
 package dto
 
 import (
-	"errors"
 	"fluxend/internal/config/constants"
 	"fluxend/internal/domain/shared"
 	"fmt"
@@ -49,18 +48,6 @@ var (
 )
 
 type BaseRequest struct {
-	ProjectUUID uuid.UUID `json:"projectUUID,omitempty"`
-}
-
-func (r *BaseRequest) WithProjectHeader(c echo.Context) error {
-	projectUUID, err := uuid.Parse(c.Request().Header.Get("X-Project"))
-	if err != nil {
-		return errors.New("invalid project UUID")
-	}
-
-	r.ProjectUUID = projectUUID
-
-	return nil
 }
 
 func (r *BaseRequest) ExtractValidationErrors(err error) []string {

--- a/internal/api/dto/database/column_requests.go
+++ b/internal/api/dto/database/column_requests.go
@@ -13,12 +13,12 @@ import (
 )
 
 type CreateColumnRequest struct {
-	dto.BaseRequest
+	dto.DefaultRequestWithProjectHeader
 	Columns []columnDomain.Column `json:"columns"`
 }
 
 type RenameColumnRequest struct {
-	dto.BaseRequest
+	dto.DefaultRequestWithProjectHeader
 	Name string `json:"name"`
 }
 

--- a/internal/api/dto/database/function_requests.go
+++ b/internal/api/dto/database/function_requests.go
@@ -16,7 +16,7 @@ type functionParameter struct {
 }
 
 type CreateFunctionRequest struct {
-	dto.BaseRequest
+	dto.DefaultRequestWithProjectHeader
 	Name       string              `json:"name"`
 	Parameters []functionParameter `json:"parameters"`
 	Definition string              `json:"definition"`

--- a/internal/api/dto/database/index_requests.go
+++ b/internal/api/dto/database/index_requests.go
@@ -11,7 +11,7 @@ import (
 )
 
 type CreateIndexRequest struct {
-	dto.BaseRequest
+	dto.DefaultRequestWithProjectHeader
 	Name     string   `json:"name"`
 	Columns  []string `json:"columns"`
 	IsUnique bool     `json:"is_unique"`

--- a/internal/api/dto/database/table_requests.go
+++ b/internal/api/dto/database/table_requests.go
@@ -14,18 +14,18 @@ import (
 )
 
 type CreateTableRequest struct {
-	dto.BaseRequest
+	dto.DefaultRequestWithProjectHeader
 	Name    string                `json:"name"`
 	Columns []columnDomain.Column `json:"columns"`
 }
 
 type RenameTableRequest struct {
-	dto.BaseRequest
+	dto.DefaultRequestWithProjectHeader
 	Name string `json:"name"`
 }
 
 type UploadTableRequest struct {
-	dto.BaseRequest
+	dto.DefaultRequestWithProjectHeader
 	Name string                `form:"name"`
 	File *multipart.FileHeader `form:"file"`
 }

--- a/internal/api/dto/form/requests.go
+++ b/internal/api/dto/form/requests.go
@@ -22,7 +22,7 @@ var allowedFieldTypes = []interface{}{
 }
 
 type CreateRequest struct {
-	dto.BaseRequest
+	dto.DefaultRequestWithProjectHeader
 	Name        string `json:"name"`
 	Description string `json:"description"`
 }
@@ -53,17 +53,17 @@ type FieldRequest struct {
 
 // CreateFormFieldsRequest represents multiple fields in a request
 type CreateFormFieldsRequest struct {
-	dto.BaseRequest
+	dto.DefaultRequestWithProjectHeader
 	Fields []FieldRequest `json:"fields"`
 }
 
 type UpdateFormFieldRequest struct {
-	dto.BaseRequest
+	dto.DefaultRequestWithProjectHeader
 	FieldRequest
 }
 
 type CreateResponseRequest struct {
-	dto.BaseRequest
+	dto.DefaultRequestWithProjectHeader
 	Response map[string]interface{} `json:"response"`
 }
 

--- a/internal/api/dto/project/requests.go
+++ b/internal/api/dto/project/requests.go
@@ -11,14 +11,14 @@ import (
 )
 
 type CreateRequest struct {
-	dto.BaseRequest
+	dto.DefaultRequestWithProjectHeader
 	Name             string    `json:"name"`
 	Description      string    `json:"description"`
 	OrganizationUUID uuid.UUID `json:"organization_uuid"`
 }
 
 type UpdateRequest struct {
-	dto.BaseRequest
+	dto.DefaultRequestWithProjectHeader
 	Name        string `json:"name"`
 	Description string `json:"description"`
 }

--- a/internal/api/dto/storage/container/requests.go
+++ b/internal/api/dto/storage/container/requests.go
@@ -10,7 +10,7 @@ import (
 )
 
 type CreateRequest struct {
-	dto.BaseRequest
+	dto.DefaultRequestWithProjectHeader
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	IsPublic    bool   `json:"is_public"`

--- a/internal/api/dto/storage/file/requests.go
+++ b/internal/api/dto/storage/file/requests.go
@@ -10,13 +10,13 @@ import (
 )
 
 type CreateRequest struct {
-	dto.BaseRequest
+	dto.DefaultRequestWithProjectHeader
 	FullFileName string                `json:"-" form:"full_file_name"`
 	File         *multipart.FileHeader `json:"-" form:"file"`
 }
 
 type RenameRequest struct {
-	dto.BaseRequest
+	dto.DefaultRequestWithProjectHeader
 	FullFileName string `json:"full_file_name"`
 }
 

--- a/internal/api/handlers/backup.go
+++ b/internal/api/handlers/backup.go
@@ -33,8 +33,8 @@ func NewBackupHandler(injector *do.Injector) (*BackupHandler, error) {
 // @Param X-Project header string true "Project UUID"
 //
 // @Success 200 {array} response.Response{content=[]backup.Response} "List of backups"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /backups [get]
 func (bh *BackupHandler) List(c echo.Context) error {
@@ -67,9 +67,9 @@ func (bh *BackupHandler) List(c echo.Context) error {
 // @Param backupUUID path string true "Backup UUID"
 //
 // @Success 200 {object} response.Response{content=backup.Response} "Backup details"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /backups/{backupUUID} [get]
 func (bh *BackupHandler) Show(c echo.Context) error {
@@ -145,9 +145,9 @@ func (bh *BackupHandler) Store(c echo.Context) error {
 // @Param backupUUID path string true "Backup UUID"
 //
 // @Success 204 "Backup deleted"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /backups/{backupUUID} [delete]
 func (bh *BackupHandler) Delete(c echo.Context) error {

--- a/internal/api/handlers/backup.go
+++ b/internal/api/handlers/backup.go
@@ -108,10 +108,10 @@ func (bh *BackupHandler) Show(c echo.Context) error {
 // @Param backup body dto.DefaultRequestWithProjectHeader true "Project UUID"
 //
 // @Success 201 {object} response.Response{content=backup.Response} "Backup created"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /backups [post]
 func (bh *BackupHandler) Store(c echo.Context) error {

--- a/internal/api/handlers/column.go
+++ b/internal/api/handlers/column.go
@@ -35,9 +35,9 @@ func NewColumnHandler(injector *do.Injector) (*ColumnHandler, error) {
 // @param Header X-Project header string true "Project UUID"
 //
 // @Success 200 {object} response.Response{content=[]database.ColumnResponse} "List of columns"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /tables/{fullTableName}/columns [get]
 func (ch *ColumnHandler) List(c echo.Context) error {
@@ -77,10 +77,10 @@ func (ch *ColumnHandler) List(c echo.Context) error {
 // @Param columns body database.CreateColumnRequest true "Columns JSON"
 //
 // @Success 201 {object} response.Response{content=database.ColumnResponse} "Columns created"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 422 "Unprocessable entity"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /tables/{fullTableName}/columns [post]
 func (ch *ColumnHandler) Store(c echo.Context) error {
@@ -120,10 +120,10 @@ func (ch *ColumnHandler) Store(c echo.Context) error {
 // @Param columns body database.CreateColumnRequest true "Updated column definitions"
 //
 // @Success 200 {object} response.Response{content=database.ColumnResponse} "Columns altered"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 422 "Unprocessable entity"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /tables/{fullTableName}/columns [put]
 func (ch *ColumnHandler) Alter(c echo.Context) error {
@@ -164,10 +164,10 @@ func (ch *ColumnHandler) Alter(c echo.Context) error {
 // @Param new_name body database.RenameColumnRequest true "New column name JSON"
 //
 // @Success 200 {object} response.Response "Column renamed"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 422 "Unprocessable entity"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /tables/{fullTableName}/columns/{columnName} [put]
 func (ch *ColumnHandler) Rename(c echo.Context) error {

--- a/internal/api/handlers/container.go
+++ b/internal/api/handlers/container.go
@@ -39,9 +39,9 @@ func NewContainerHandler(injector *do.Injector) (*ContainerHandler, error) {
 // @Param order query string false "Sort order (asc or desc)"
 //
 // @Success 200 {object} response.Response{content=[]container.Response} "List of container"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Invalid input response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /storage [get]
 func (ch *ContainerHandler) List(c echo.Context) error {
@@ -76,10 +76,10 @@ func (ch *ContainerHandler) List(c echo.Context) error {
 // @Param containerUUID path string true "Container UUID"
 //
 // @Success 200 {object} response.Response{content=container.Response} "Container details"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Invalid input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /storage/containers/{containerUUID} [get]
 func (ch *ContainerHandler) Show(c echo.Context) error {
@@ -114,10 +114,10 @@ func (ch *ContainerHandler) Show(c echo.Context) error {
 // @Param container body container.CreateRequest true "Container details"
 //
 // @Success 201 {object} response.Response{content=container.Response} "Container created"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Invalid input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /storage [post]
 func (ch *ContainerHandler) Store(c echo.Context) error {
@@ -152,10 +152,10 @@ func (ch *ContainerHandler) Store(c echo.Context) error {
 // @Param container body container.CreateRequest true "Container details"
 //
 // @Success 200 {object} response.Response{content=container.Response} "Container updated"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /storage/containers/{containerUUID} [put]
 func (ch *ContainerHandler) Update(c echo.Context) error {

--- a/internal/api/handlers/container.go
+++ b/internal/api/handlers/container.go
@@ -194,9 +194,9 @@ func (ch *ContainerHandler) Update(c echo.Context) error {
 // @Param containerUUID path string true "Container UUID"
 //
 // @Success 204 "Container deleted"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /storage/containers/{containerUUID} [delete]
 func (ch *ContainerHandler) Delete(c echo.Context) error {

--- a/internal/api/handlers/file.go
+++ b/internal/api/handlers/file.go
@@ -31,6 +31,8 @@ func NewFileHandler(injector *do.Injector) (*FileHandler, error) {
 // @Produce json
 //
 // @Param Authorization header string true "Bearer Token"
+// @Param X-Project header string true "Project UUID"
+//
 // @Param containerUUID path string true "Container UUID"
 //
 // @Param page query string false "Page number for pagination"
@@ -76,6 +78,8 @@ func (fh *FileHandler) List(c echo.Context) error {
 // @Produce json
 //
 // @Param Authorization header string true "Bearer Token"
+// @Param X-Project header string true "Project UUID"
+//
 // @Param containerUUID path string true "Container UUID"
 // @Param fileUUID path string true "File UUID"
 //
@@ -121,6 +125,8 @@ func (fh *FileHandler) Show(c echo.Context) error {
 // @Produce json
 //
 // @Param Authorization header string true "Bearer Token"
+// @Param X-Project header string true "Project UUID"
+//
 // @Param containerUUID path string true "Container UUID"
 // @Param file body file.CreateRequest true "File details"
 //
@@ -161,6 +167,8 @@ func (fh *FileHandler) Store(c echo.Context) error {
 // @Produce json
 //
 // @Param Authorization header string true "Bearer Token"
+// @Param X-Project header string true "Project UUID"
+//
 // @Param containerUUID path string true "Container UUID"
 // @Param fileUUID path string true "File UUID"
 // @Param file body file.RenameRequest true "New file name"
@@ -207,6 +215,8 @@ func (fh *FileHandler) Rename(c echo.Context) error {
 // @Produce json
 //
 // @Param Authorization header string true "Bearer Token"
+// @Param X-Project header string true "Project UUID"
+//
 // @Param containerUUID path string true "Container UUID"
 // @Param fileUUID path string true "File UUID"
 //

--- a/internal/api/handlers/file.go
+++ b/internal/api/handlers/file.go
@@ -39,9 +39,9 @@ func NewFileHandler(injector *do.Injector) (*FileHandler, error) {
 // @Param order query string false "Sort order (asc or desc)"
 //
 // @Success 200 {array} response.Response{content=[]file.Response} "List of files"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /containers/{containerUUID}/files [get]
 func (fh *FileHandler) List(c echo.Context) error {
@@ -80,9 +80,9 @@ func (fh *FileHandler) List(c echo.Context) error {
 // @Param fileUUID path string true "File UUID"
 //
 // @Success 200 {object} response.Response{content=file.Response} "File details"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /containers/{containerUUID}/files/{fileUUID} [get]
 func (fh *FileHandler) Show(c echo.Context) error {
@@ -125,9 +125,9 @@ func (fh *FileHandler) Show(c echo.Context) error {
 // @Param file body file.CreateRequest true "File details"
 //
 // @Success 201 {object} response.Response{content=file.Response} "File details"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /containers/{containerUUID}/files [post]
 func (fh *FileHandler) Store(c echo.Context) error {
@@ -166,9 +166,9 @@ func (fh *FileHandler) Store(c echo.Context) error {
 // @Param file body file.RenameRequest true "New file name"
 //
 // @Success 200 {object} response.Response{content=file.Response} "File details"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /containers/{containerUUID}/files/{fileUUID}/rename [put]
 func (fh *FileHandler) Rename(c echo.Context) error {
@@ -211,9 +211,9 @@ func (fh *FileHandler) Rename(c echo.Context) error {
 // @Param fileUUID path string true "File UUID"
 //
 // @Success 204 "File deleted"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /containers/{containerUUID}/files/{fileUUID} [delete]
 func (fh *FileHandler) Delete(c echo.Context) error {

--- a/internal/api/handlers/form.go
+++ b/internal/api/handlers/form.go
@@ -39,9 +39,9 @@ func NewFormHandler(injector *do.Injector) (*FormHandler, error) {
 // @Param order query string false "Sort order (asc or desc)"
 //
 // @Success 200 {array} response.Response{content=[]form.Response} "List of forms"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /forms [get]
 func (fh *FormHandler) List(c echo.Context) error {
@@ -75,9 +75,9 @@ func (fh *FormHandler) List(c echo.Context) error {
 // @Param formUUID path string true "Form UUID"
 //
 // @Success 200 {object} response.Response{content=form.Response} "Form details"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /forms/{formUUID} [get]
 func (fh *FormHandler) Show(c echo.Context) error {
@@ -196,9 +196,9 @@ func (fh *FormHandler) Update(c echo.Context) error {
 // @Param formUUID path string true "Form UUID"
 //
 // @Success 204 "Form deleted"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /forms/{formUUID} [delete]
 func (fh *FormHandler) Delete(c echo.Context) error {

--- a/internal/api/handlers/form.go
+++ b/internal/api/handlers/form.go
@@ -116,10 +116,10 @@ func (fh *FormHandler) Show(c echo.Context) error {
 // @Param form body form.CreateRequest true "Form name and description"
 //
 // @Success 201 {object} response.Response{content=form.Response} "Form created"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /forms [post]
 func (fh *FormHandler) Store(c echo.Context) error {
@@ -154,10 +154,10 @@ func (fh *FormHandler) Store(c echo.Context) error {
 // @Param form body form.CreateRequest true "Form name and description"
 //
 // @Success 200 {object} response.Response{content=form.Response} "Form updated"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /forms/{formUUID} [put]
 func (fh *FormHandler) Update(c echo.Context) error {

--- a/internal/api/handlers/form_field.go
+++ b/internal/api/handlers/form_field.go
@@ -114,10 +114,10 @@ func (ffh *FormFieldHandler) Show(c echo.Context) error {
 // @Param formUUID path string true "Form UUID"
 //
 // @Success 201 {object} response.Response{content=form.FieldResponseApi} "Field created"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /forms/{formUUID}/fields [post]
 func (ffh *FormFieldHandler) Store(c echo.Context) error {
@@ -156,10 +156,10 @@ func (ffh *FormFieldHandler) Store(c echo.Context) error {
 // @Param fieldUUID path string true "Field UUID"
 //
 // @Success 200 {object} response.Response{content=form.FieldResponseApi} "Field updated"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /forms/{formUUID}/fields/{fieldUUID} [put]
 func (ffh *FormFieldHandler) Update(c echo.Context) error {

--- a/internal/api/handlers/form_field.go
+++ b/internal/api/handlers/form_field.go
@@ -34,9 +34,9 @@ func NewFormFieldHandler(injector *do.Injector) (*FormFieldHandler, error) {
 // @Param formUUID path string true "Form UUID"
 //
 // @Success 200 {array} response.Response{content=[]form.FieldResponseApi} "List of fields"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /forms/{formUUID}/fields [get]
 func (ffh *FormFieldHandler) List(c echo.Context) error {
@@ -74,9 +74,9 @@ func (ffh *FormFieldHandler) List(c echo.Context) error {
 // @Param fieldUUID path string true "Field UUID"
 //
 // @Success 200 {object} response.Response{content=form.FieldResponseApi} "Field details"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /forms/{formUUID}/fields/{fieldUUID} [get]
 func (ffh *FormFieldHandler) Show(c echo.Context) error {
@@ -202,9 +202,9 @@ func (ffh *FormFieldHandler) Update(c echo.Context) error {
 // @Param fieldUUID path string true "Field UUID"
 //
 // @Success 204 "Field deleted"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /forms/{formUUID}/fields/{fieldUUID} [delete]
 func (ffh *FormFieldHandler) Delete(c echo.Context) error {

--- a/internal/api/handlers/form_response.go
+++ b/internal/api/handlers/form_response.go
@@ -120,10 +120,10 @@ func (ffh *FormResponseHandler) Show(c echo.Context) error {
 // @Param request body form.CreateResponseRequest true "Request body to create a new form response"
 //
 // @Success 201 {object} response.Response{content=form.ResponseForAPI} "Form response details"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /forms/{formUUID}/responses [post]
 func (ffh *FormResponseHandler) Store(c echo.Context) error {

--- a/internal/api/handlers/form_response.go
+++ b/internal/api/handlers/form_response.go
@@ -36,9 +36,9 @@ func NewFormResponseHandler(injector *do.Injector) (*FormResponseHandler, error)
 // @Param formUUID path string true "Form UUID"
 //
 // @Success 200 {object} response.Response{content=[]form.ResponseForAPI} "List of form responses"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /forms/{formUUID}/responses [get]
 func (ffh *FormResponseHandler) List(c echo.Context) error {
@@ -78,9 +78,9 @@ func (ffh *FormResponseHandler) List(c echo.Context) error {
 // @Param formResponseUUID path string true "Form Response UUID"
 //
 // @Success 200 {object} response.Response{content=form.ResponseForAPI} "Form response details"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /forms/{formUUID}/responses/{formResponseUUID} [get]
 func (ffh *FormResponseHandler) Show(c echo.Context) error {
@@ -163,9 +163,9 @@ func (ffh *FormResponseHandler) Store(c echo.Context) error {
 // @Param formResponseUUID path string true "Form Response UUID"
 //
 // @Success 204 "Form response deleted"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /forms/{formUUID}/responses/{formResponseUUID} [delete]
 func (ffh *FormResponseHandler) Delete(c echo.Context) error {

--- a/internal/api/handlers/function.go
+++ b/internal/api/handlers/function.go
@@ -37,9 +37,9 @@ func NewFunctionHandler(injector *do.Injector) (*FunctionHandler, error) {
 // @Param schema path string true "Schema to search under"
 //
 // @Success 200 {array} response.Response{content=[]database.FunctionResponse} "List of functions"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /functions/{schema} [get]
 func (fh *FunctionHandler) List(c echo.Context) error {
@@ -79,9 +79,9 @@ func (fh *FunctionHandler) List(c echo.Context) error {
 // @Param functionName path string true "Function name"
 //
 // @Success 200 {object} response.Response{content=database.FunctionResponse} "Function details"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /functions/{schema}/{functionName} [get]
 func (fh *FunctionHandler) Show(c echo.Context) error {
@@ -169,9 +169,9 @@ func (fh *FunctionHandler) Store(c echo.Context) error {
 // @Param functionName path string true "Function name"
 //
 // @Success 204 "Form deleted"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /functions/{schema}/{functionName} [delete]
 func (fh *FunctionHandler) Delete(c echo.Context) error {

--- a/internal/api/handlers/function.go
+++ b/internal/api/handlers/function.go
@@ -125,10 +125,10 @@ func (fh *FunctionHandler) Show(c echo.Context) error {
 // @Param function body database.CreateFunctionRequest true "Function details"
 //
 // @Success 201 {object} response.Response{content=database.FunctionResponse} "Function created"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /functions/{schema} [post]
 func (fh *FunctionHandler) Store(c echo.Context) error {

--- a/internal/api/handlers/index.go
+++ b/internal/api/handlers/index.go
@@ -33,9 +33,9 @@ func NewIndexHandler(injector *do.Injector) (*IndexHandler, error) {
 // @Param tableUUID path string true "Table UUID"
 //
 // @Success 200 {object} response.Response{content=[]dto.GenericResponse} "List of indexes"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /tables/{tableUUID}/indexes [get]
 func (ih *IndexHandler) List(c echo.Context) error {
@@ -116,10 +116,10 @@ func (ih *IndexHandler) Show(c echo.Context) error {
 // @Param index body database.CreateIndexRequest true "Index details JSON"
 //
 // @Success 201 {object} response.Response{content=dto.GenericResponse} "Index created"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 422 "Unprocessable entity"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /tables/{tableUUID}/indexes [post]
 func (ih *IndexHandler) Store(c echo.Context) error {

--- a/internal/api/handlers/log.go
+++ b/internal/api/handlers/log.go
@@ -43,9 +43,9 @@ func NewLogHandler(injector *do.Injector) (*LogHandler, error) {
 // @Param order query string false "Sort order (asc or desc)"
 //
 // @Success 200 {array} response.Response{content=[]logging.Response} "List of files"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /admin/logs [get]
 func (lh *LogHandler) List(c echo.Context) error {

--- a/internal/api/handlers/organization.go
+++ b/internal/api/handlers/organization.go
@@ -72,10 +72,10 @@ func (oh *OrganizationHandler) List(c echo.Context) error {
 // @Param organization_id path string true "Organization ID"
 //
 // @Success 200 {object} response.Response{content=organization.Response} "Organization details"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /organizations/{organizationUUID} [get]
 func (oh *OrganizationHandler) Show(c echo.Context) error {
@@ -112,10 +112,10 @@ func (oh *OrganizationHandler) Show(c echo.Context) error {
 // @Param organization body organization.CreateRequest true "Organization name"
 //
 // @Success 201 {object} response.Response{content=organization.Response} "Organization created"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /organizations [post]
 func (oh *OrganizationHandler) Store(c echo.Context) error {
@@ -151,10 +151,10 @@ func (oh *OrganizationHandler) Store(c echo.Context) error {
 // @Param organization body organization.CreateRequest true "Updated organization details"
 //
 // @Success 200 {object} response.Response{content=organization.Response} "Organization updated"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /organizations/{organizationUUID} [put]
 func (oh *OrganizationHandler) Update(c echo.Context) error {

--- a/internal/api/handlers/organization_member.go
+++ b/internal/api/handlers/organization_member.go
@@ -34,10 +34,10 @@ func NewOrganizationMemberHandler(injector *do.Injector) (*OrganizationMemberHan
 // @Param organization_id path string true "Organization ID"
 //
 // @Success 201 {object} response.Response{content=[]user.Response} "User created"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /organizations/{organizationUUID}/users [get]
 func (omh *OrganizationMemberHandler) List(c echo.Context) error {
@@ -75,10 +75,10 @@ func (omh *OrganizationMemberHandler) List(c echo.Context) error {
 // @Param user body organization.MemberCreateRequest true "User ID JSON"
 //
 // @Success 201 {object} response.Response{content=user.Response} "User created"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /organizations/{organizationUUID}/users [post]
 func (omh *OrganizationMemberHandler) Store(c echo.Context) error {
@@ -116,10 +116,10 @@ func (omh *OrganizationMemberHandler) Store(c echo.Context) error {
 // @Param user_id path string true "User ID"
 //
 // @Success 204 {object} nil "User deleted"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /organizations/{organizationUUID}/users/{userUUID} [delete]
 func (omh *OrganizationMemberHandler) Delete(c echo.Context) error {

--- a/internal/api/handlers/project.go
+++ b/internal/api/handlers/project.go
@@ -79,10 +79,10 @@ func (ph *ProjectHandler) List(c echo.Context) error {
 // @Param projectUUID path string true "Project UUID"
 //
 // @Success 200 {object} response.Response{content=project.Response} "Project details"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /projects/{projectUUID} [get]
 func (ph *ProjectHandler) Show(c echo.Context) error {
@@ -120,10 +120,10 @@ func (ph *ProjectHandler) Show(c echo.Context) error {
 // @Param name body project.CreateRequest true "Project name"
 //
 // @Success 201 {object} response.Response{content=project.Response} "Project details"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /projects [post]
 func (ph *ProjectHandler) Store(c echo.Context) error {
@@ -156,10 +156,10 @@ func (ph *ProjectHandler) Store(c echo.Context) error {
 // @Param name body project.UpdateRequest true "Project name"
 //
 // @Success 200 {object} response.Response{content=project.Response} "Project details"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /projects/{projectUUID} [put]
 func (ph *ProjectHandler) Update(c echo.Context) error {

--- a/internal/api/handlers/project.go
+++ b/internal/api/handlers/project.go
@@ -39,9 +39,9 @@ func NewProjectHandler(injector *do.Injector) (*ProjectHandler, error) {
 // @Param order query string false "Sort order (asc or desc)"
 //
 // @Success 200 {object} response.Response{content=[]project.Response} "List of projects"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /projects [get]
 func (ph *ProjectHandler) List(c echo.Context) error {
@@ -196,9 +196,9 @@ func (ph *ProjectHandler) Update(c echo.Context) error {
 // @Param projectUUID path string true "Project UUID"
 //
 // @Success 200 {object} response.Response{} "Project deleted"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /projects/{projectUUID} [delete]
 func (ph *ProjectHandler) Delete(c echo.Context) error {

--- a/internal/api/handlers/setting.go
+++ b/internal/api/handlers/setting.go
@@ -60,10 +60,10 @@ func (sh *SettingHandler) List(c echo.Context) error {
 // @Param form body setting.UpdateRequest true "Settings update request"
 //
 // @Success 200 {object} response.Response{content=[]setting.Response} "Form updated"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /admin/settings [put]
 func (sh *SettingHandler) Update(c echo.Context) error {
@@ -94,10 +94,10 @@ func (sh *SettingHandler) Update(c echo.Context) error {
 // @Param Authorization header string true "Bearer Token"
 //
 // @Success 200 {object} response.Response{content=[]setting.Response} "Settings reset"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /admin/settings/reset [put]
 func (sh *SettingHandler) Reset(c echo.Context) error {

--- a/internal/api/handlers/setting.go
+++ b/internal/api/handlers/setting.go
@@ -32,9 +32,9 @@ func NewSettingHandler(injector *do.Injector) (*SettingHandler, error) {
 // @Param Authorization header string true "Bearer Token"
 //
 // @Success 200 {object} response.Response{content=[]setting.Response} "List of indexes"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /admin/settings [get]
 func (sh *SettingHandler) List(c echo.Context) error {

--- a/internal/api/handlers/table.go
+++ b/internal/api/handlers/table.go
@@ -34,9 +34,9 @@ func NewTableHandler(injector *do.Injector) (*TableHandler, error) {
 // @param Header X-Project header string true "Project UUID"
 //
 // @Success 200 {object} response.Response{content=[]database.TableResponse} "List of tables"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /tables [get]
 func (th *TableHandler) List(c echo.Context) error {
@@ -112,10 +112,10 @@ func (th *TableHandler) Show(c echo.Context) error {
 // @Param table body database.CreateTableRequest true "Table definition JSON"
 //
 // @Success 201 {object} response.Response{content=database.TableResponse} "Table created"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 422 "Unprocessable entity"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /tables [post]
 func (th *TableHandler) Store(c echo.Context) error {
@@ -149,10 +149,10 @@ func (th *TableHandler) Store(c echo.Context) error {
 // @Param table body database.UploadTableRequest true "Table definition multipart/form-data"
 //
 // @Success 201 {object} response.Response{content=database.TableResponse} "Table created"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 422 "Unprocessable entity"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /tables/upload [post]
 func (th *TableHandler) Upload(c echo.Context) error {
@@ -187,10 +187,10 @@ func (th *TableHandler) Upload(c echo.Context) error {
 // @Param new_name body database.RenameTableRequest true "Duplicate table name JSON"
 //
 // @Success 201 {object} response.Response{content=database.TableResponse} "Table duplicated"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 422 "Unprocessable entity"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /tables/{tableUUID}/duplicate [put]
 func (th *TableHandler) Duplicate(c echo.Context) error {
@@ -230,10 +230,10 @@ func (th *TableHandler) Duplicate(c echo.Context) error {
 // @Param new_name body database.RenameTableRequest true "New table name JSON"
 //
 // @Success 200 {object} response.Response{content=database.TableResponse} "Table renamed"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 422 "Unprocessable entity"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /tables/{tableUUID}/rename [put]
 func (th *TableHandler) Rename(c echo.Context) error {

--- a/internal/api/handlers/user.go
+++ b/internal/api/handlers/user.go
@@ -42,9 +42,9 @@ func NewUserHandler(injector *do.Injector) (*UserHandler, error) {
 // @Param id path string true "User UUID"
 //
 // @Success 200 {object} response.Response{content=user.Response} "User details"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /users/{userUUID} [get]
 func (uh *UserHandler) Show(c echo.Context) error {
@@ -109,9 +109,9 @@ func (uh *UserHandler) Me(c echo.Context) error {
 // @Param user body user.LoginRequest true "Login request"
 //
 // @Success 200 {object} response.Response{content=user.Response} "User details"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /users/login [post]
 func (uh *UserHandler) Login(c echo.Context) error {
@@ -232,9 +232,9 @@ func (uh *UserHandler) Update(c echo.Context) error {
 // @Param Authorization header string true "Bearer Token"
 //
 // @Success 200 {object} response.Response{} "User logged out"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /users/logout [post]
 func (uh *UserHandler) Logout(c echo.Context) error {

--- a/internal/api/handlers/user.go
+++ b/internal/api/handlers/user.go
@@ -190,10 +190,10 @@ func (uh *UserHandler) Store(c echo.Context) error {
 // @Param user body user.UpdateRequest true "User details"
 //
 // @Success 200 {object} response.Response{content=user.Response} "User updated"
-// @Failure 422 "Unprocessable entity"
-// @Failure 400 "Invalid input"
-// @Failure 401 "Unauthorized"
-// @Failure 500 "Internal server error"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
 // @Router /users/{userUUID} [put]
 func (uh *UserHandler) Update(c echo.Context) error {

--- a/internal/api/response/bad_request.go
+++ b/internal/api/response/bad_request.go
@@ -7,7 +7,7 @@ import (
 )
 
 func BadRequestResponse(c echo.Context, error string) error {
-	response := Response{
+	response := BadRequestErrorResponse{
 		Success: false,
 		Errors:  []string{message.Message(error)},
 		Content: nil,

--- a/internal/api/response/base.go
+++ b/internal/api/response/base.go
@@ -2,6 +2,42 @@ package response
 
 type Response struct {
 	Success bool        `json:"success"`
-	Errors  []string    `json:"errors"`
-	Content interface{} `json:"content"`
+	Errors  []string    `json:"errors,omitempty"`
+	Content interface{} `json:"content,omitempty"`
+}
+
+type BadRequestErrorResponse struct {
+	Success bool     `json:"success" example:"false"`
+	Errors  []string `json:"errors" example:"Invalid input parameter"`
+	Content *string  `json:"content" example:"null"`
+}
+
+type UnauthorizedErrorResponse struct {
+	Success bool     `json:"success" example:"false"`
+	Errors  []string `json:"errors" example:"Unauthorized access"`
+	Content *string  `json:"content" example:"null"`
+}
+
+type UnprocessableErrorResponse struct {
+	Success bool     `json:"success" example:"false"`
+	Errors  []string `json:"errors" example:"Validation failed"`
+	Content *string  `json:"content" example:"null"`
+}
+
+type InternalServerErrorResponse struct {
+	Success bool     `json:"success" example:"false"`
+	Errors  []string `json:"errors" example:"Internal server error"`
+	Content *string  `json:"content" example:"null"`
+}
+
+type NotFoundErrorResponse struct {
+	Success bool     `json:"success" example:"false"`
+	Errors  []string `json:"errors" example:"Resource not found"`
+	Content *string  `json:"content" example:"null"`
+}
+
+type ForbiddenErrorResponse struct {
+	Success bool     `json:"success" example:"false"`
+	Errors  []string `json:"errors" example:"Forbidden access"`
+	Content *string  `json:"content" example:"null"`
 }

--- a/internal/api/response/forbidden.go
+++ b/internal/api/response/forbidden.go
@@ -7,7 +7,7 @@ import (
 )
 
 func ForbiddenResponse(c echo.Context, error string) error {
-	response := Response{
+	response := ForbiddenErrorResponse{
 		Success: false,
 		Errors:  []string{message.Message(error)},
 		Content: nil,

--- a/internal/api/response/internal_server.go
+++ b/internal/api/response/internal_server.go
@@ -7,7 +7,7 @@ import (
 )
 
 func InternalServerResponse(c echo.Context, error string) error {
-	response := Response{
+	response := InternalServerErrorResponse{
 		Success: false,
 		Errors:  []string{message.Message(error)},
 		Content: nil,

--- a/internal/api/response/not_found.go
+++ b/internal/api/response/not_found.go
@@ -7,7 +7,7 @@ import (
 )
 
 func NotFoundResponse(c echo.Context, error string) error {
-	response := Response{
+	response := NotFoundErrorResponse{
 		Success: false,
 		Errors:  []string{message.Message(error)},
 		Content: nil,

--- a/internal/api/response/unauthorized.go
+++ b/internal/api/response/unauthorized.go
@@ -7,7 +7,7 @@ import (
 )
 
 func UnauthorizedResponse(c echo.Context, error string) error {
-	response := Response{
+	response := UnauthorizedErrorResponse{
 		Success: false,
 		Errors:  []string{message.Message(error)},
 		Content: nil,

--- a/internal/api/response/unprocessable.go
+++ b/internal/api/response/unprocessable.go
@@ -6,7 +6,7 @@ import (
 )
 
 func UnprocessableResponse(c echo.Context, errors []string) error {
-	response := Response{
+	response := UnprocessableErrorResponse{
 		Success: false,
 		Errors:  errors,
 		Content: nil,


### PR DESCRIPTION
**Why**
API docs were inconsistent and missing error response examples. Devs integrating with our API had no idea what error responses looked like.

**Changes**
- Add error response examples for all endpoints (400/401/422/500)
- Fix missing/incorrect required headers
- Fix broken request examples
- Make docs consistent across endpoints

Should make integration way less painful.