### PR TITLE
fix: Add text wrapping to Request Body in log detail sheet

### DIFF
--- a/web/app/routes/logs/log-detail-sheet.tsx
+++ b/web/app/routes/logs/log-detail-sheet.tsx
@@ -222,7 +222,7 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
                 <Separator />
                 <div>
                   <h3 className="text-sm font-semibold mb-3">Request Body</h3>
-                  <pre className="bg-muted p-3 rounded-lg overflow-x-auto text-xs">
+                  <pre className="bg-muted p-3 rounded-lg overflow-x-auto text-xs whitespace-pre-wrap break-all">
                     {JSON.stringify(log.body, null, 2)}
                   </pre>
                 </div>
@@ -235,7 +235,7 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
                 <Separator />
                 <div>
                   <h3 className="text-sm font-semibold mb-3">Query Parameters</h3>
-                  <pre className="bg-muted p-3 rounded-lg overflow-x-auto text-xs">
+                  <pre className="bg-muted p-3 rounded-lg overflow-x-auto text-xs whitespace-pre-wrap break-all">
                     {JSON.stringify(log.params, null, 2)}
                   </pre>
                 </div>


### PR DESCRIPTION
## Summary
Fixes text overflow issue in the log detail sheet where long JSON content in Request Body and Query Parameters sections would extend beyond the container.

## Changes
- Added `whitespace-pre-wrap` and `break-all` CSS classes to the `<pre>` elements
- This ensures long text wraps within the container instead of causing horizontal overflow
- Applied to both Request Body and Query Parameters sections

## Before
- Long JSON content would overflow horizontally requiring scrolling
- Made it difficult to read the full content on smaller screens

## After
- Text wraps properly within the container
- All content is visible without horizontal scrolling
- Maintains JSON formatting while improving readability

## Test Plan
- [x] Open log detail sheet with long Request Body content
- [x] Verify text wraps instead of overflowing
- [x] Check that JSON formatting is preserved
- [x] Test on different screen sizes