### PR TITLE
fix: Improve text overflow handling across multiple components

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -398,3 +398,13 @@ th[data-column-type="timestamp"] {
   contain: layout style paint;
   will-change: scroll-position;
 }
+
+/* Text overflow utilities */
+.text-wrap-anywhere {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.overflow-wrap-anywhere {
+  overflow-wrap: anywhere;
+}

--- a/web/app/routes/logs/log-detail-sheet.tsx
+++ b/web/app/routes/logs/log-detail-sheet.tsx
@@ -222,7 +222,7 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
                 <Separator />
                 <div>
                   <h3 className="text-sm font-semibold mb-3">Request Body</h3>
-                  <pre className="bg-muted p-3 rounded-lg overflow-x-auto text-xs">
+                  <pre className="bg-muted p-3 rounded-lg overflow-x-auto text-xs whitespace-pre-wrap break-all">
                     {JSON.stringify(log.body, null, 2)}
                   </pre>
                 </div>
@@ -235,7 +235,7 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
                 <Separator />
                 <div>
                   <h3 className="text-sm font-semibold mb-3">Query Parameters</h3>
-                  <pre className="bg-muted p-3 rounded-lg overflow-x-auto text-xs">
+                  <pre className="bg-muted p-3 rounded-lg overflow-x-auto text-xs whitespace-pre-wrap break-all">
                     {JSON.stringify(log.params, null, 2)}
                   </pre>
                 </div>

--- a/web/app/routes/logs/log-detail-sheet.tsx
+++ b/web/app/routes/logs/log-detail-sheet.tsx
@@ -124,8 +124,8 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
                       </td>
                       <td className="px-4 py-3">
                         <div className="flex items-center">
-                          <Badge variant="outline" className="font-mono max-w-full">
-                            <span className="truncate">{log.endpoint}</span>
+                          <Badge variant="outline" className="font-mono max-w-full overflow-hidden">
+                            <span className="truncate block">{log.endpoint}</span>
                           </Badge>
                           <SheetCopyButton text={log.endpoint} label="endpoint" />
                         </div>
@@ -195,8 +195,8 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
                         </td>
                         <td className="px-4 py-3">
                           <div className="flex items-center">
-                            <Badge variant="outline" className="font-mono text-xs max-w-full">
-                              <span className="truncate">{log.userUuid}</span>
+                            <Badge variant="outline" className="font-mono text-xs max-w-full overflow-hidden">
+                              <span className="truncate block">{log.userUuid}</span>
                             </Badge>
                             <SheetCopyButton text={log.userUuid} label="user ID" />
                           </div>
@@ -208,7 +208,7 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
                         User Agent
                       </td>
                       <td className="px-4 py-3">
-                        <div className="text-sm break-all">{log.userAgent}</div>
+                        <div className="text-sm break-words overflow-wrap-anywhere">{log.userAgent}</div>
                       </td>
                     </tr>
                   </tbody>

--- a/web/app/routes/projects/components/project-card.tsx
+++ b/web/app/routes/projects/components/project-card.tsx
@@ -51,7 +51,7 @@ const ProjectCard = ({ project, onClick }: ProjectCardProps) => {
 
       {/* Card Footer - Actions */}
       <div className="mt-3 pt-3 border-t border-muted flex items-center justify-between">
-        <p className="text-xs text-gray-400 dark:text-gray-500 font-mono truncate">
+        <p className="text-xs text-gray-400 dark:text-gray-500 font-mono truncate max-w-[200px]" title={project.uuid}>
           {project.uuid}
         </p>
         {/* <div className="flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">

--- a/web/app/routes/tables/columns.tsx
+++ b/web/app/routes/tables/columns.tsx
@@ -294,7 +294,7 @@ export const prepareColumns = (
           header: () => (
             <div className="inline-flex items-center whitespace-nowrap">
               <ColumnIcon type={column.type} />
-              <span className="truncate font-medium">
+              <span className="truncate font-medium block max-w-[200px]">
                 {column && column.name ? column.name : ""}
               </span>
             </div>
@@ -348,7 +348,7 @@ export const prepareColumns = (
             }
 
             return (
-              <span>
+              <span className="block truncate max-w-[300px]" title={value !== null && value !== undefined ? String(value) : ""}>
                 {value !== null && value !== undefined ? String(value) : ""}
               </span>
             );

--- a/web/app/routes/tables/table-list.tsx
+++ b/web/app/routes/tables/table-list.tsx
@@ -110,7 +110,7 @@ export const TableList = ({
           key={table.name}
           className={({ isActive }) =>
             [
-              `relative flex flex-col items-start whitespace-nowrap p-2 rounded-lg mx-2  text-sm leading-tight hover:text-foreground/70 cursor-pointer ${
+              `relative flex flex-col items-start p-2 rounded-lg mx-2 text-sm leading-tight hover:text-foreground/70 cursor-pointer overflow-hidden ${
                 isFetching ? "opacity-60" : ""
               }`,
               isActive ? "dark:text-primary" : "",
@@ -132,9 +132,9 @@ export const TableList = ({
                     }}
                   />
                 )}
-                <HashIcon size={12} />
-                <span className="">{table.name}</span>
-                <span className="ml-auto text-xs">{table.totalSize}</span>
+                <HashIcon size={12} className="flex-shrink-0" />
+                <span className="truncate flex-1 min-w-0">{table.name}</span>
+                <span className="ml-auto text-xs flex-shrink-0">{table.totalSize}</span>
               </div>
             </>
           )}


### PR DESCRIPTION
## Summary
Comprehensive fix for text overflow issues across multiple components in the application, ensuring long text content is properly handled without breaking layouts.

## Changes

### 1. Log Detail Sheet (`log-detail-sheet.tsx`)
- Changed User Agent from `break-all` to `overflow-wrap-anywhere` for better word breaking
- Added `overflow-hidden` to badges containing endpoint and user UUID
- Made truncated spans use `block` display for proper truncation

### 2. Table Columns (`tables/columns.tsx`)
- Added `max-w-[200px]` to column headers with truncation
- Added `max-w-[300px]` and title attributes to cell values for better UX

### 3. Table List (`table-list.tsx`)
- Removed `whitespace-nowrap` that was preventing proper wrapping
- Added flex properties (`flex-1 min-w-0`) to allow proper truncation
- Added `flex-shrink-0` to icons and size indicators

### 4. Project Card (`project-card.tsx`)
- Added `max-w-[200px]` constraint to UUID display
- Added title attribute for full UUID on hover

### 5. Global CSS (`globals.css`)
- Added utility classes for better text wrapping:
  - `.text-wrap-anywhere`: Combines overflow-wrap and word-break
  - `.overflow-wrap-anywhere`: For modern text wrapping

## Before
- User Agent text would break at awkward positions with `break-all`
- Long table names would cause horizontal scrolling
- UUIDs and endpoints would overflow their containers
- No tooltips for truncated content

## After
- Improved text wrapping that respects word boundaries
- Proper truncation with ellipsis for long content
- Title attributes show full content on hover
- No horizontal overflow in any component

## Test Plan
- [x] Test log detail sheet with long User Agent strings
- [x] Test table columns with long column names
- [x] Test table list with long table names
- [x] Test project cards with long UUIDs
- [x] Verify no horizontal scrolling occurs
- [x] Check tooltips appear on truncated content