### PR TITLE
feat: add tooltips to project sidebar menu items

### DIFF
--- a/web/app/components/shared/project-sidebar.tsx
+++ b/web/app/components/shared/project-sidebar.tsx
@@ -131,7 +131,7 @@ export const ProjectSidebar = memo(
                         <SidebarMenuButton
                           asChild
                           isActive={isActive}
-                          // tooltip={item.title}
+                          tooltip={item.title}
                           className="isolate hover:bg-transparent active:bg-transparent data-[active=true]:bg-transparent dark:active:text-primary dark:data-[active=true]:text-primary hover:text-foreground/70 transition-colors duration-300"
                         >
                           <item.Icon />


### PR DESCRIPTION
Enables tooltips for sidebar navigation items (Dashboard, Tables, Logs) to improve user experience by showing item names on hover in the icon-only sidebar.

Closes #125