### PR TITLE
fix: Fix logs pagination and performance issues

### DIFF
--- a/web/app/routes/logs/page.tsx
+++ b/web/app/routes/logs/page.tsx
@@ -6,7 +6,7 @@ import { RefreshButton } from "~/components/shared/refresh-button";
 import { Button } from "~/components/ui/button";
 import { RefreshCw, Pause, Play } from "lucide-react";
 import type { ProjectLayoutOutletContext } from "~/components/shared/project-layout";
-import { InfiniteLogsTable } from "./infinite-logs-table";
+import { VirtualizedLogsTable } from "./virtualized-logs-table";
 import { createLogsColumns } from "./columns";
 import { LogFilters } from "./log-filters";
 import { LogDetailSheet } from "./log-detail-sheet";
@@ -150,7 +150,7 @@ export default function Logs() {
           </div>
         ) : (
           <div className="rounded-lg border h-full">
-            <InfiniteLogsTable
+            <VirtualizedLogsTable
               columns={columns}
               data={allLogs}
               onRowClick={handleRowClick}

--- a/web/app/routes/logs/page.tsx
+++ b/web/app/routes/logs/page.tsx
@@ -46,20 +46,23 @@ export default function Logs() {
     hasNextPage,
   } = useInfiniteQuery({
     queryKey: ["logs", projectId, queryFilters],
-    queryFn: async ({ pageParam = 0 }) => {
+    queryFn: async ({ pageParam = 1 }) => {
       if (!projectId) throw new Error("Project ID required");
       return services.logs.getLogs(projectId, {
         ...queryFilters,
-        offset: pageParam,
+        page: pageParam,
       });
     },
     enabled: !!projectId,
     refetchInterval: autoRefresh ? refreshInterval : false,
     getNextPageParam: (lastPage, pages) => {
-      const loadedCount = pages.reduce((acc, page) => acc + page.content.length, 0);
-      return loadedCount < lastPage.totalCount ? loadedCount : undefined;
+      // If we got a full page of results, there might be more
+      if (lastPage.content.length === LOGS_PER_PAGE) {
+        return pages.length + 1;
+      }
+      return undefined;
     },
-    initialPageParam: 0,
+    initialPageParam: 1,
     // Keep existing data when refetching
     refetchOnMount: false,
     refetchOnWindowFocus: false,

--- a/web/app/routes/logs/virtualized-logs-table.tsx
+++ b/web/app/routes/logs/virtualized-logs-table.tsx
@@ -1,0 +1,173 @@
+import { useRef, useEffect, useCallback, useMemo } from "react";
+import { flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import type { ColumnDef } from "@tanstack/react-table";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/components/ui/table";
+import { cn } from "~/lib/utils";
+import { Loader2 } from "lucide-react";
+import type { LogEntry } from "~/services/logs";
+
+interface VirtualizedLogsTableProps {
+  columns: ColumnDef<LogEntry>[];
+  data: LogEntry[];
+  onRowClick?: (row: LogEntry) => void;
+  fetchNextPage: () => void;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  isLoading: boolean;
+}
+
+export function VirtualizedLogsTable({
+  columns,
+  data,
+  onRowClick,
+  fetchNextPage,
+  hasNextPage,
+  isFetchingNextPage,
+  isLoading,
+}: VirtualizedLogsTableProps) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const tableContainerRef = useRef<HTMLDivElement>(null);
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  const { rows } = table.getRowModel();
+
+  // Row virtualizer
+  const rowVirtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollContainerRef.current,
+    estimateSize: () => 48, // Estimated row height
+    overscan: 10,
+  });
+
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const totalSize = rowVirtualizer.getTotalSize();
+
+  // Handle infinite scroll
+  const lastItem = virtualRows[virtualRows.length - 1];
+  useEffect(() => {
+    if (!lastItem) return;
+
+    if (
+      lastItem.index >= rows.length - 1 &&
+      hasNextPage &&
+      !isFetchingNextPage
+    ) {
+      fetchNextPage();
+    }
+  }, [hasNextPage, fetchNextPage, isFetchingNextPage, lastItem, rows.length]);
+
+  const paddingTop = virtualRows.length > 0 ? virtualRows[0]?.start || 0 : 0;
+  const paddingBottom =
+    virtualRows.length > 0
+      ? totalSize - (virtualRows[virtualRows.length - 1]?.end || 0)
+      : 0;
+
+  if (isLoading && data.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (data.length === 0 && !isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <span className="text-muted-foreground">No logs found</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Scrollable container */}
+      <div 
+        ref={scrollContainerRef}
+        className="flex-1 overflow-auto"
+      >
+        <div ref={tableContainerRef}>
+          <Table>
+            <TableHeader className="sticky top-0 z-10 bg-background">
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <TableHead 
+                      key={header.id}
+                      style={{ width: header.column.getSize() }}
+                    >
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(header.column.columnDef.header, header.getContext())}
+                    </TableHead>
+                  ))}
+                </TableRow>
+              ))}
+            </TableHeader>
+            <TableBody>
+              {paddingTop > 0 && (
+                <tr>
+                  <td style={{ height: `${paddingTop}px` }} />
+                </tr>
+              )}
+              {virtualRows.map((virtualRow) => {
+                const row = rows[virtualRow.index];
+                return (
+                  <TableRow
+                    key={row.id}
+                    className={cn(
+                      "cursor-pointer hover:bg-muted/50",
+                      "data-[state=selected]:bg-muted"
+                    )}
+                    onClick={(e) => {
+                      // Don't trigger row click if clicking on a clickable element
+                      const target = e.target as HTMLElement;
+                      if (target.closest('[data-no-row-click]')) {
+                        return;
+                      }
+                      onRowClick?.(row.original);
+                    }}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell 
+                        key={cell.id}
+                        style={{ width: cell.column.getSize() }}
+                      >
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                );
+              })}
+              {paddingBottom > 0 && (
+                <tr>
+                  <td style={{ height: `${paddingBottom}px` }} />
+                </tr>
+              )}
+            </TableBody>
+          </Table>
+          
+          {/* Loading indicator at the bottom */}
+          {isFetchingNextPage && (
+            <div className="h-20 flex items-center justify-center">
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                <span className="text-sm">Loading more logs...</span>
+              </div>
+            </div>
+          )}
+          {!hasNextPage && data.length > 0 && (
+            <div className="h-20 flex items-center justify-center">
+              <span className="text-sm text-muted-foreground">No more logs to load</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/app/services/logs.ts
+++ b/web/app/services/logs.ts
@@ -28,39 +28,21 @@ export interface LogsFilters {
   ipAddress?: string;
   page?: number;
   limit?: number;
-  offset?: number;
   sort?: string;
-  order?: 'asc' | 'desc' | string; // Can be 'asc'/'desc' or PostgREST format "column.desc"
+  order?: "asc" | "desc";
 }
 
 export function createLogsService(authToken: string) {
   const getLogs = async (projectId: string, filters?: LogsFilters) => {
-    // Build headers with PostgREST Prefer header for count
+    // Build headers
     const headers: Record<string, string> = {
       "X-Project": projectId,
       "Content-Type": "application/json",
       Authorization: `Bearer ${authToken}`,
-      Prefer: "count=exact", // Request exact count from PostgREST
     };
 
-    // Build query params
+    // Build query params - API expects page, limit, sort, order
     const params: any = { ...filters };
-    
-    // Convert sort/order to PostgREST format
-    if (params.sort && params.order) {
-      // PostgREST expects format like "createdAt.desc" or "createdAt.asc"
-      params.order = `${params.sort}.${params.order}`;
-      delete params.sort;
-    }
-    
-    // If using offset/limit, try Range header approach
-    // But keep the params as fallback in case server doesn't support Range headers
-    if (filters?.offset !== undefined && filters?.limit !== undefined) {
-      const start = filters.offset;
-      const end = filters.offset + filters.limit - 1;
-      headers["Range-Unit"] = "items";
-      headers["Range"] = `${start}-${end}`;
-    }
 
     const fetchOptions: APIRequestOptions = {
       headers,
@@ -68,7 +50,7 @@ export function createLogsService(authToken: string) {
     };
 
     const response = await get("/admin/logs", fetchOptions);
-    
+
     if (!response.ok && response.status > 500) {
       throw new Error("Unexpected Error");
     }
@@ -79,30 +61,11 @@ export function createLogsService(authToken: string) {
       throw new Error(data.errors?.[0] || "Unexpected Error");
     }
 
-    // Extract total count from Content-Range header
-    // PostgREST format: "start-end/total" or "start-end/*"
-    let totalCount = 0;
-    const contentRange = response.headers.get("Content-Range");
-    if (contentRange) {
-      // Try to match the full format first
-      const fullMatch = contentRange.match(/(\d+)-(\d+)\/(\d+|\*)/);
-      if (fullMatch) {
-        const [, start, end, total] = fullMatch;
-        if (total !== "*") {
-          totalCount = parseInt(total, 10);
-        }
-      } else {
-        // Fallback to simpler format
-        const simpleMatch = contentRange.match(/\/(\d+|\*)/);
-        if (simpleMatch && simpleMatch[1] !== "*") {
-          totalCount = parseInt(simpleMatch[1], 10);
-        }
-      }
-    }
-
+    // Since we're using page-based pagination, we don't have exact count
+    // You might need to get this from a separate endpoint or response metadata
     return {
       content: data.content || [],
-      totalCount,
+      totalCount: 0, // TODO: Get actual count from API response or separate endpoint
     };
   };
 
@@ -112,3 +75,4 @@ export function createLogsService(authToken: string) {
 }
 
 export type LogsService = ReturnType<typeof createLogsService>;
+


### PR DESCRIPTION
## Summary
- Remove PostgREST Prefer header that was causing server errors
- Switch to standard page-based pagination as per API documentation
- Implement table virtualization to fix performance issues with large datasets

## Changes

### 1. Fixed Pagination (`/app/services/logs.ts`)
- Removed `Prefer: count=exact` header that was causing 500 errors
- Removed PostgREST-specific offset/limit handling
- Simplified to use standard `page`, `limit`, `sort`, `order` parameters

### 2. Updated Infinite Query (`/app/routes/logs/page.tsx`)
- Changed from offset-based to page-based pagination
- Start with page 1 instead of offset 0
- Continue loading if full page received (instead of relying on totalCount)

### 3. Added Virtualization (`/app/routes/logs/virtualized-logs-table.tsx`)
- Created new virtualized table component using `@tanstack/react-virtual`
- Only renders visible rows (20-30) instead of thousands
- Maintains scroll position with calculated padding
- Prevents DOM memory issues and page hanging

## Problems Fixed
- ✅ Server errors from Prefer header
- ✅ Page hanging with large datasets
- ✅ Table becoming empty after scrolling
- ✅ Memory issues from too many DOM nodes

## Test Plan
- [x] Verify logs load without server errors
- [x] Test infinite scroll continues loading new pages
- [x] Scroll through hundreds of logs without performance issues
- [x] Verify smooth scrolling experience
- [x] Check that row clicks still work properly
- [x] Ensure copy functionality works on visible rows