### PR TITLE
feat: Add React Error Boundary to logs page

### DIFF
--- a/web/app/components/shared/error-boundary.tsx
+++ b/web/app/components/shared/error-boundary.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { Button } from "~/components/ui/button";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback?: React.ComponentType<{ error: Error; reset: () => void }>;
+  onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+}
+
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error("ErrorBoundary caught an error:", error, errorInfo);
+    this.props.onError?.(error, errorInfo);
+  }
+
+  resetError = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError && this.state.error) {
+      if (this.props.fallback) {
+        const FallbackComponent = this.props.fallback;
+        return <FallbackComponent error={this.state.error} reset={this.resetError} />;
+      }
+
+      return <DefaultErrorFallback error={this.state.error} reset={this.resetError} />;
+    }
+
+    return this.props.children;
+  }
+}
+
+interface ErrorFallbackProps {
+  error: Error;
+  reset: () => void;
+}
+
+function DefaultErrorFallback({ error, reset }: ErrorFallbackProps) {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[400px] p-6">
+      <div className="text-center space-y-4 max-w-md">
+        <div className="flex justify-center">
+          <AlertTriangle className="h-12 w-12 text-destructive" />
+        </div>
+        <h2 className="text-2xl font-semibold">Something went wrong</h2>
+        <p className="text-muted-foreground">
+          An unexpected error occurred while loading this content.
+        </p>
+        {import.meta.env.DEV && (
+          <details className="text-left">
+            <summary className="cursor-pointer text-sm text-muted-foreground hover:text-foreground">
+              Error details
+            </summary>
+            <pre className="mt-2 p-3 bg-muted rounded-md text-xs overflow-auto max-h-48">
+              {error.message}
+              {error.stack && '\n\n' + error.stack}
+            </pre>
+          </details>
+        )}
+        <Button onClick={reset} className="mt-4">
+          <RefreshCw className="mr-2 h-4 w-4" />
+          Try again
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// Custom error fallback specifically for the logs page
+export function LogsErrorFallback({ error, reset }: ErrorFallbackProps) {
+  return (
+    <div className="flex flex-col items-center justify-center h-full p-6">
+      <div className="text-center space-y-4 max-w-md">
+        <div className="flex justify-center">
+          <AlertTriangle className="h-10 w-10 text-destructive" />
+        </div>
+        <h3 className="text-lg font-semibold">Failed to load logs</h3>
+        <p className="text-sm text-muted-foreground">
+          {error.message || "An unexpected error occurred while loading the logs."}
+        </p>
+        <div className="flex gap-2 justify-center">
+          <Button onClick={reset} size="sm">
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Retry
+          </Button>
+          <Button 
+            variant="outline" 
+            size="sm"
+            onClick={() => window.location.reload()}
+          >
+            Refresh page
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/app/routes/logs/page.tsx
+++ b/web/app/routes/logs/page.tsx
@@ -5,6 +5,7 @@ import { DataTableSkeleton } from "~/components/shared/data-table-skeleton";
 import { RefreshButton } from "~/components/shared/refresh-button";
 import { Button } from "~/components/ui/button";
 import { RefreshCw, Pause, Play } from "lucide-react";
+import { ErrorBoundary, LogsErrorFallback } from "~/components/shared/error-boundary";
 import type { ProjectLayoutOutletContext } from "~/components/shared/project-layout";
 import { LogsTable } from "./logs-table";
 import { createLogsColumns } from "./columns";
@@ -15,7 +16,7 @@ import type { LogsFilters, LogEntry } from "~/services/logs";
 const LOGS_PER_PAGE = 100;
 const MAX_PAGES_IN_MEMORY = 5; // Keep maximum 5 pages (500 logs) in memory
 
-export default function Logs() {
+function LogsContent() {
   const { projectDetails, services } =
     useOutletContext<ProjectLayoutOutletContext>();
   const projectId = projectDetails?.uuid;
@@ -186,16 +187,18 @@ export default function Logs() {
             <DataTableSkeleton columns={7} rows={10} />
           </div>
         ) : (
-          <LogsTable
-            columns={columns}
-            data={allLogs}
-            onRowClick={handleRowClick}
-            fetchNextPage={fetchNextPage}
-            hasNextPage={hasNextPage ?? false}
-            isFetchingNextPage={isFetchingNextPage}
-            isLoading={isLoading}
-            error={error}
-          />
+          <ErrorBoundary fallback={LogsErrorFallback}>
+            <LogsTable
+              columns={columns}
+              data={allLogs}
+              onRowClick={handleRowClick}
+              fetchNextPage={fetchNextPage}
+              hasNextPage={hasNextPage ?? false}
+              isFetchingNextPage={isFetchingNextPage}
+              isLoading={isLoading}
+              error={error}
+            />
+          </ErrorBoundary>
         )}
       </div>
 
@@ -205,5 +208,13 @@ export default function Logs() {
         onOpenChange={setSheetOpen}
       />
     </div>
+  );
+}
+
+export default function Logs() {
+  return (
+    <ErrorBoundary fallback={LogsErrorFallback}>
+      <LogsContent />
+    </ErrorBoundary>
   );
 }


### PR DESCRIPTION
## Summary
- Added comprehensive error handling to the logs page with React Error Boundaries
- Provides graceful fallback UI when errors occur
- Includes retry functionality to recover from transient errors

## Changes
- Created reusable `ErrorBoundary` component with customizable fallback
- Added specific `LogsErrorFallback` component for logs-related errors
- Wrapped entire logs page in error boundary for top-level error catching
- Added nested error boundary around LogsTable for granular error handling
- Included retry button and page refresh option in error UI
- Show detailed error information in development mode for debugging
- Proper error logging to console for monitoring

## Test plan
1. Open the logs page
2. To test error handling, temporarily throw an error in LogsTable component
3. Verify the error fallback UI appears with appropriate message
4. Click "Retry" button to attempt recovery
5. Click "Refresh page" to reload the entire page
6. In dev mode, verify error details are visible
7. Check console for error logging

Fixes #143