### PR TITLE
Fix multiple issues with logs page filtering and display

### DIFF
--- a/web/app/lib/utils.ts
+++ b/web/app/lib/utils.ts
@@ -41,13 +41,16 @@ export function formatTimestamp(timestamp: string): {
   relativeTime: string;
 } {
   try {
-    const date = new Date(timestamp);
+    // Parse the timestamp - if it doesn't end with 'Z', assume it's UTC and add it
+    const utcTimestamp = timestamp.endsWith('Z') ? timestamp : `${timestamp}Z`;
+    const date = new Date(utcTimestamp);
 
     // Check if date is valid
     if (isNaN(date.getTime())) {
       return { date: "Invalid date", time: "", fullDate: "", relativeTime: "" };
     }
 
+    // Now date is in user's local timezone
     // Format date as "Mon DD, YYYY"
     const monthNames = [
       "Jan",
@@ -67,7 +70,7 @@ export function formatTimestamp(timestamp: string): {
     const day = date.getDate();
     const year = date.getFullYear();
 
-    // Format time as "HH:MM AM/PM"
+    // Format time as "HH:MM AM/PM" in local timezone
     let hours = date.getHours();
     const minutes = date.getMinutes().toString().padStart(2, "0");
     const seconds = date.getSeconds().toString().padStart(2, "0");
@@ -105,7 +108,7 @@ export function formatTimestamp(timestamp: string): {
       relativeTime = "Just now";
     }
 
-    // Full ISO date for tooltip
+    // Full date for tooltip (in local timezone)
     const fullDate = `${year}-${(date.getMonth() + 1)
       .toString()
       .padStart(2, "0")}-${day.toString().padStart(2, "0")} ${hours

--- a/web/app/routes/logs/columns.tsx
+++ b/web/app/routes/logs/columns.tsx
@@ -52,7 +52,7 @@ const CopyIndicator = ({ text, label }: { text: string; label: string }) => {
   }, []);
   
   return (
-    <div className="group flex items-center gap-1 -m-2 p-2" data-no-row-click>
+    <div className="group flex items-center gap-1 -m-2 p-2">
       {label === "IP Address" ? (
         <Badge variant="outline" className="font-mono">
           {text}
@@ -67,6 +67,7 @@ const CopyIndicator = ({ text, label }: { text: string; label: string }) => {
         size="icon"
         className="h-6 w-6 p-0 transition-all duration-200 opacity-0 scale-75 group-hover:opacity-100 group-hover:scale-100"
         onClick={handleCopy}
+        data-no-row-click
       >
         {copied ? (
           <Check className="h-3 w-3 text-green-600" />
@@ -208,7 +209,11 @@ export const createLogsColumns = (): ColumnDef<LogEntry>[] => [
     ),
     cell: ({ row }) => {
       const ip = row.getValue<string>("ipAddress");
-      return <CopyIndicator text={ip} label="IP Address" />;
+      return (
+        <div className="-m-2 p-2">
+          <CopyIndicator text={ip} label="IP Address" />
+        </div>
+      );
     },
   },
   {

--- a/web/app/routes/logs/log-detail-sheet.tsx
+++ b/web/app/routes/logs/log-detail-sheet.tsx
@@ -107,7 +107,9 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
   if (!log) return null;
 
   const statusInfo = getStatusInfo(log.status);
-  const formattedDate = format(new Date(log.createdAt), "PPpp");
+  // Parse the timestamp - if it doesn't end with 'Z', assume it's UTC and add it
+  const utcTimestamp = log.createdAt.endsWith('Z') ? log.createdAt : `${log.createdAt}Z`;
+  const formattedDate = format(new Date(utcTimestamp), "PPpp");
   const parsedBody = parseJsonSafely(log.body);
   const parsedParams = parseJsonSafely(log.params);
 

--- a/web/app/services/logs.ts
+++ b/web/app/services/logs.ts
@@ -48,8 +48,6 @@ export interface LogsFilters {
   method?: string;
   endpoint?: string;
   ipAddress?: string;
-  dateStart?: string;
-  dateEnd?: string;
   startTime?: number; // Unix timestamp
   endTime?: number; // Unix timestamp
   page?: number;
@@ -70,9 +68,9 @@ export function createLogsService(authToken: string) {
     const params: Record<string, string | number | undefined> = filters ? {
       ...filters,
       limit: filters.limit || 100, // Default limit
-      // Convert numbers to strings for query params
-      ...(filters.startTime && { startTime: filters.startTime.toString() }),
-      ...(filters.endTime && { endTime: filters.endTime.toString() }),
+      // Keep startTime and endTime as numbers for the API
+      ...(filters.startTime && { startTime: filters.startTime }),
+      ...(filters.endTime && { endTime: filters.endTime }),
     } : {
       limit: 100,
     };


### PR DESCRIPTION
## Summary
This PR addresses multiple issues reported in #149 related to the logs page filtering functionality and display.

### Changes Made:
- **Fixed time-based filtering**: Removed `dateStart`/`dateEnd` parameters to use only `startTime`/`endTime` as the API expects
- **Timezone handling**: All timestamps now display in the user's local timezone while maintaining UTC for API communication
- **URL parameter sync**: Filter states are now reflected in the URL, allowing users to share and bookmark filtered views
- **Click interactions**: Fixed the issue where clicking on endpoint/IP fields wasn't opening the detail drawer
- **Clear filters button**: Now shows when a custom time range is applied (not just for non-time filters)

### Technical Details:
1. **API Integration**: Simplified to use only Unix timestamps (`startTime`/`endTime`)
2. **Timezone Conversion**: 
   - User enters time in local timezone
   - Converted to UTC for API requests
   - Displayed back in local timezone
3. **URL State Management**: Uses React Router's `useSearchParams` for filter persistence
4. **Component Updates**: Fixed event propagation in table cells to allow both copy and row click functionality

## Test Plan
- [ ] Apply various time filters and verify logs are filtered correctly
- [ ] Check that all timestamps display in your local timezone
- [ ] Copy the URL after applying filters and verify it restores the same view when pasted
- [ ] Click on endpoint/IP fields to verify the detail drawer opens
- [ ] Click the copy button on endpoint/IP fields to verify it copies without opening the drawer
- [ ] Apply only a time filter (no other filters) and verify the "Clear Filters" button appears
- [ ] Click "Clear Filters" and verify it resets to today's date range

Fixes #149