### PR TITLE
Fix: Add page titles to all routes for better tab identification

### DIFF
--- a/web/app/routes/auth/signup.tsx
+++ b/web/app/routes/auth/signup.tsx
@@ -25,8 +25,8 @@ import { NeonCard } from "~/components/shared/neon-card";
 
 export function meta({}: Route.MetaArgs) {
   return [
-    { title: "Frontend for Fluxend" },
-    { name: "description", content: "Login to Fluxend" },
+    { title: "Sign Up - Fluxend" },
+    { name: "description", content: "Sign up for Fluxend" },
   ];
 }
 

--- a/web/app/routes/dashboard/page.tsx
+++ b/web/app/routes/dashboard/page.tsx
@@ -22,6 +22,13 @@ import type { ProjectLayoutOutletContext } from "~/components/shared/project-lay
 import { getAuthToken, getClientAuthToken } from "~/lib/auth";
 import { initializeServices } from "~/services";
 
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "Dashboard - Fluxend" },
+    { name: "description", content: "Fluxend Dashboard" },
+  ];
+}
+
 function StatusCard({
   title,
   status,

--- a/web/app/routes/functions/page.tsx
+++ b/web/app/routes/functions/page.tsx
@@ -1,4 +1,12 @@
 import { AppHeader } from "~/components/shared/header";
+import type { Route } from "./+types/page";
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "Functions - Fluxend" },
+    { name: "description", content: "Manage your serverless functions" },
+  ];
+}
 
 export default function Functions() {
   return (

--- a/web/app/routes/logs/page.tsx
+++ b/web/app/routes/logs/page.tsx
@@ -11,6 +11,14 @@ import { createLogsColumns } from "./columns";
 import { LogFilters } from "./log-filters";
 import { LogDetailSheet } from "./log-detail-sheet";
 import type { LogsFilters, LogEntry } from "~/services/logs";
+import type { Route } from "./+types/page";
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "Logs - Fluxend" },
+    { name: "description", content: "View and manage your application logs" },
+  ];
+}
 
 const LOGS_PER_PAGE = 100;
 const MAX_PAGES_IN_MEMORY = 5; // Keep maximum 5 pages (500 logs) in memory

--- a/web/app/routes/projects/page.tsx
+++ b/web/app/routes/projects/page.tsx
@@ -18,6 +18,13 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "~/components/ui/dialog";
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "Projects - Fluxend" },
+    { name: "description", content: "Manage your Fluxend projects" },
+  ];
+}
 import { Label } from "~/components/ui/label";
 import { Input } from "~/components/ui/input";
 import { useEffect, useState } from "react";

--- a/web/app/routes/settings/page.tsx
+++ b/web/app/routes/settings/page.tsx
@@ -1,4 +1,12 @@
 import { AppHeader } from "~/components/shared/header";
+import type { Route } from "./+types/page";
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "Settings - Fluxend" },
+    { name: "description", content: "Manage your account settings" },
+  ];
+}
 
 export default function Settings() {
   return (

--- a/web/app/routes/storage/page.tsx
+++ b/web/app/routes/storage/page.tsx
@@ -1,5 +1,13 @@
 import React from "react";
 import { AppHeader } from "~/components/shared/header";
+import type { Route } from "./+types/page";
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "Storage - Fluxend" },
+    { name: "description", content: "Manage your file storage" },
+  ];
+}
 
 export default function Storage() {
   return (

--- a/web/app/routes/tables/page.tsx
+++ b/web/app/routes/tables/page.tsx
@@ -18,6 +18,13 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "~/components/ui/alert-dialog";
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "Tables - Fluxend" },
+    { name: "description", content: "Manage your database tables" },
+  ];
+}
 import { Button } from "~/components/ui/button";
 import { Trash2, Pencil } from "lucide-react";
 import { toast } from "sonner";


### PR DESCRIPTION
## Summary
This PR adds descriptive page titles to all routes that were missing them, making it easier to identify tabs when multiple are open.

## Changes
- Added meta functions with titles to: Dashboard, Projects, Logs, Tables, Storage, Functions, and Settings routes
- Updated signup page title from "Frontend for Fluxend" to "Sign Up - Fluxend" for consistency
- All pages now follow the format "[Page Name] - Fluxend"

## Test Plan
- [x] Navigate to each page and verify the browser tab shows the correct title
- [x] Open multiple tabs and confirm they can be easily distinguished
- [x] Verify no TypeScript errors with `yarn typecheck`

## Screenshots
Before: Browser tabs show no titles or generic titles
After: Each tab shows descriptive titles like "Dashboard - Fluxend", "Logs - Fluxend", etc.

Closes #134