### PR TITLE
[Fix] Modify Update Column Endpoint Behavior

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5200,12 +5200,12 @@
                     }
                 }
             },
-            "put": {
-                "description": "Alter the data type of existing columns in a specified table.",
+            "post": {
+                "description": "Create new columns in a specified table within a project.",
                 "tags": [
                     "Columns"
                 ],
-                "summary": "Modify columns",
+                "summary": "Create column",
                 "parameters": [
                     {
                         "description": "Bearer Token",
@@ -5243,12 +5243,12 @@
                             }
                         }
                     },
-                    "description": "Updated column definitions",
+                    "description": "Columns JSON",
                     "required": true
                 },
                 "responses": {
-                    "200": {
-                        "description": "Columns altered",
+                    "201": {
+                        "description": "Columns created",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -5311,12 +5311,12 @@
                     }
                 }
             },
-            "post": {
-                "description": "Create new columns in a specified table within a project.",
+            "patch": {
+                "description": "Update the data type of existing columns in a specified table and remove any columns not included in the request.",
                 "tags": [
                     "Columns"
                 ],
-                "summary": "Create column",
+                "summary": "Modify columns",
                 "parameters": [
                     {
                         "description": "Bearer Token",
@@ -5354,12 +5354,12 @@
                             }
                         }
                     },
-                    "description": "Columns JSON",
+                    "description": "Updated column definitions",
                     "required": true
                 },
                 "responses": {
-                    "201": {
-                        "description": "Columns created",
+                    "200": {
+                        "description": "Columns altered",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4305,95 +4305,6 @@
                     }
                 }
             },
-            "put": {
-                "description": "Alter the data type of existing columns in a specified table.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Columns"
-                ],
-                "summary": "Modify columns",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Bearer Token",
-                        "name": "Authorization",
-                        "in": "header",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Project UUID",
-                        "name": "X-Project",
-                        "in": "header",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Full table name",
-                        "name": "fullTableName",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Updated column definitions",
-                        "name": "columns",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/database.CreateColumnRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Columns altered",
-                        "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "content": {
-                                            "$ref": "#/definitions/database.ColumnResponse"
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request response",
-                        "schema": {
-                            "$ref": "#/definitions/response.BadRequestErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized response",
-                        "schema": {
-                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable input response",
-                        "schema": {
-                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error response",
-                        "schema": {
-                            "$ref": "#/definitions/response.InternalServerErrorResponse"
-                        }
-                    }
-                }
-            },
             "post": {
                 "description": "Create new columns in a specified table within a project.",
                 "consumes": [
@@ -4441,6 +4352,95 @@
                 "responses": {
                     "201": {
                         "description": "Columns created",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/response.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "content": {
+                                            "$ref": "#/definitions/database.ColumnResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request response",
+                        "schema": {
+                            "$ref": "#/definitions/response.BadRequestErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnauthorizedErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable input response",
+                        "schema": {
+                            "$ref": "#/definitions/response.UnprocessableErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error response",
+                        "schema": {
+                            "$ref": "#/definitions/response.InternalServerErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Update the data type of existing columns in a specified table and remove any columns not included in the request.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Columns"
+                ],
+                "summary": "Modify columns",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bearer Token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Project UUID",
+                        "name": "X-Project",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Full table name",
+                        "name": "fullTableName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated column definitions",
+                        "name": "columns",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/database.CreateColumnRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Columns altered",
                         "schema": {
                             "allOf": [
                                 {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3373,6 +3373,64 @@ paths:
       summary: List columns
       tags:
       - Columns
+    patch:
+      consumes:
+      - application/json
+      description: Update the data type of existing columns in a specified table and
+        remove any columns not included in the request.
+      parameters:
+      - description: Bearer Token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Project UUID
+        in: header
+        name: X-Project
+        required: true
+        type: string
+      - description: Full table name
+        in: path
+        name: fullTableName
+        required: true
+        type: string
+      - description: Updated column definitions
+        in: body
+        name: columns
+        required: true
+        schema:
+          $ref: '#/definitions/database.CreateColumnRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Columns altered
+          schema:
+            allOf:
+            - $ref: '#/definitions/response.Response'
+            - properties:
+                content:
+                  $ref: '#/definitions/database.ColumnResponse'
+              type: object
+        "400":
+          description: Bad request response
+          schema:
+            $ref: '#/definitions/response.BadRequestErrorResponse'
+        "401":
+          description: Unauthorized response
+          schema:
+            $ref: '#/definitions/response.UnauthorizedErrorResponse'
+        "422":
+          description: Unprocessable input response
+          schema:
+            $ref: '#/definitions/response.UnprocessableErrorResponse'
+        "500":
+          description: Internal server error response
+          schema:
+            $ref: '#/definitions/response.InternalServerErrorResponse'
+      summary: Modify columns
+      tags:
+      - Columns
     post:
       consumes:
       - application/json
@@ -3428,63 +3486,6 @@ paths:
           schema:
             $ref: '#/definitions/response.InternalServerErrorResponse'
       summary: Create column
-      tags:
-      - Columns
-    put:
-      consumes:
-      - application/json
-      description: Alter the data type of existing columns in a specified table.
-      parameters:
-      - description: Bearer Token
-        in: header
-        name: Authorization
-        required: true
-        type: string
-      - description: Project UUID
-        in: header
-        name: X-Project
-        required: true
-        type: string
-      - description: Full table name
-        in: path
-        name: fullTableName
-        required: true
-        type: string
-      - description: Updated column definitions
-        in: body
-        name: columns
-        required: true
-        schema:
-          $ref: '#/definitions/database.CreateColumnRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: Columns altered
-          schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                content:
-                  $ref: '#/definitions/database.ColumnResponse'
-              type: object
-        "400":
-          description: Bad request response
-          schema:
-            $ref: '#/definitions/response.BadRequestErrorResponse'
-        "401":
-          description: Unauthorized response
-          schema:
-            $ref: '#/definitions/response.UnauthorizedErrorResponse'
-        "422":
-          description: Unprocessable input response
-          schema:
-            $ref: '#/definitions/response.UnprocessableErrorResponse'
-        "500":
-          description: Internal server error response
-          schema:
-            $ref: '#/definitions/response.InternalServerErrorResponse'
-      summary: Modify columns
       tags:
       - Columns
   /tables/{fullTableName}/columns/{columnName}:

--- a/internal/api/handlers/column.go
+++ b/internal/api/handlers/column.go
@@ -139,7 +139,7 @@ func (ch *ColumnHandler) Alter(c echo.Context) error {
 		return response.BadRequestResponse(c, "Table name is required")
 	}
 
-	columns, err := ch.columnService.AlterMany(fullTableName, databaseDto.ToCreateColumnInput(request), authUser)
+	columns, err := ch.columnService.Update(fullTableName, databaseDto.ToCreateColumnInput(request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}

--- a/internal/api/handlers/column.go
+++ b/internal/api/handlers/column.go
@@ -104,10 +104,10 @@ func (ch *ColumnHandler) Store(c echo.Context) error {
 	return response.CreatedResponse(c, mapper.ToColumnResourceCollection(columns))
 }
 
-// Alter modifies column types in a table.
+// Update modifies column types in a table and deletes others
 //
 // @Summary Modify columns
-// @Description Alter the data type of existing columns in a specified table.
+// @Description Update the data type of existing columns in a specified table and remove any columns not included in the request.
 // @Tags Columns
 //
 // @Accept json
@@ -125,8 +125,8 @@ func (ch *ColumnHandler) Store(c echo.Context) error {
 // @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
 // @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
 //
-// @Router /tables/{fullTableName}/columns [put]
-func (ch *ColumnHandler) Alter(c echo.Context) error {
+// @Router /tables/{fullTableName}/columns [patch]
+func (ch *ColumnHandler) Update(c echo.Context) error {
 	var request databaseDto.CreateColumnRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)

--- a/internal/api/routes/table.go
+++ b/internal/api/routes/table.go
@@ -25,7 +25,7 @@ func RegisterTableRoutes(e *echo.Echo, container *do.Injector, authMiddleware ec
 	// column routes
 	tablesGroup.GET("/:fullTableName/columns", columnController.List)
 	tablesGroup.POST("/:fullTableName/columns", columnController.Store)
-	tablesGroup.PUT("/:fullTableName/columns", columnController.Alter)
+	tablesGroup.PATCH("/:fullTableName/columns", columnController.Update)
 	tablesGroup.PUT("/:fullTableName/columns/:columnName", columnController.Rename)
 	tablesGroup.DELETE("/:fullTableName/columns/:columnName", columnController.Delete)
 

--- a/internal/domain/database/column_repository.go
+++ b/internal/domain/database/column_repository.go
@@ -11,6 +11,7 @@ type ColumnRepository interface {
 	AlterMany(tableName string, fields []Column) error
 	Rename(tableName, oldColumnName, newColumnName string) error
 	Drop(tableName, columnName string) error
+	DropMany(tableName string, columns []Column) error
 	BuildColumnDefinition(column Column) string
 	BuildForeignKeyConstraint(tableName string, column Column) (string, bool)
 }


### PR DESCRIPTION
**Problem**
Update column endpoint was limited to changing types of columns only. This meant frontend will have to send separate requests for updating and deleting columns.

**Changes**
- Update behavior of endpoint to update columns included in request and delete ones missing
- Change request method from `PUT` to `PATCH` which is better suited for this behavior 
- Update documentation