### PR TITLE
Hide signup link in login page

### DIFF
--- a/web/app/routes/auth/login.tsx
+++ b/web/app/routes/auth/login.tsx
@@ -123,17 +123,17 @@ export default function Login({}: Route.ComponentProps) {
           <NeonCard className="shadow-md">
             <CardHeader className="text-center">
               <CardTitle className="text-xl">Sign in to your account</CardTitle>
-              <CardDescription>
-                Or{" "}
-                <NavLink to="/signup">
-                  <Button
-                    variant="link"
-                    className="p-0 font-medium text-primary hover:text-primary/80 hover:underline cusror-pointer"
-                  >
-                    create a new account
-                  </Button>
-                </NavLink>
-              </CardDescription>
+              {/* <CardDescription> */}
+              {/*   Or{" "} */}
+              {/*   <NavLink to="/signup"> */}
+              {/*     <Button */}
+              {/*       variant="link" */}
+              {/*       className="p-0 font-medium text-primary hover:text-primary/80 hover:underline cusror-pointer" */}
+              {/*     > */}
+              {/*       create a new account */}
+              {/*     </Button> */}
+              {/*   </NavLink> */}
+              {/* </CardDescription> */}
             </CardHeader>
             <CardContent>
               <div className="grid gap-6">


### PR DESCRIPTION
## Summary
- Temporarily commented out the signup link in the login page
- The "create a new account" link is now hidden from users

## Changes
- Commented out the CardDescription section containing the signup link in login.tsx
- Preserves the code for easy re-enabling in the future

## Reason
This change allows for controlling user registration access by hiding the signup option from the login page.