### PR TITLE
feat: add bulk delete functionality for table rows

### DIFF
--- a/web/app/components/shared/search-data-table-wrapper.tsx
+++ b/web/app/components/shared/search-data-table-wrapper.tsx
@@ -6,6 +6,7 @@ import type {
   ColumnDef,
   OnChangeFn,
   PaginationState,
+  RowSelectionState,
 } from "@tanstack/react-table";
 
 interface SearchDataTableWrapperProps<TData, TValue> {
@@ -24,6 +25,9 @@ interface SearchDataTableWrapperProps<TData, TValue> {
   searchQuery?: string;
   onSearchQueryChange?: (query: string) => void;
   tableMeta?: any;
+  onRowSelectionChange?: (selectedRows: TData[]) => void;
+  rowSelection?: RowSelectionState;
+  onRowSelectionStateChange?: OnChangeFn<RowSelectionState>;
 }
 
 export function SearchDataTableWrapper<TData, TValue>({
@@ -42,6 +46,9 @@ export function SearchDataTableWrapper<TData, TValue>({
   searchQuery,
   onSearchQueryChange,
   tableMeta,
+  onRowSelectionChange,
+  rowSelection,
+  onRowSelectionStateChange,
 }: SearchDataTableWrapperProps<TData, TValue>) {
   return (
     <div className="flex flex-col h-full gap-4 px-4">
@@ -67,6 +74,9 @@ export function SearchDataTableWrapper<TData, TValue>({
           onPaginationChange={onPaginationChange}
           totalRows={totalRows}
           tableMeta={tableMeta}
+          onRowSelectionChange={onRowSelectionChange}
+          rowSelection={rowSelection}
+          onRowSelectionStateChange={onRowSelectionStateChange}
         />
       </div>
     </div>

--- a/web/app/routes/tables/columns.tsx
+++ b/web/app/routes/tables/columns.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import type { ColumnDef, PaginationState, Row } from "@tanstack/react-table";
 import { Button } from "~/components/ui/button";
+import { Checkbox } from "~/components/ui/checkbox";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -148,6 +149,32 @@ export const prepareColumns = (
   if (!columns || !Array.isArray(columns) || columns.length === 0) {
     return [];
   }
+
+  // Create the select column
+  const selectColumn: ColumnDef<any, unknown> = {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={
+          table.getIsAllPageRowsSelected() ||
+          (table.getIsSomePageRowsSelected() && "indeterminate")
+        }
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+        className="ml-2"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+        className="ml-2"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  };
 
   // // Create the actions column with column visibility controls
   const ActionsColumnHeader = React.memo(({ table }: { table: any }) => {
@@ -322,7 +349,7 @@ export const prepareColumns = (
       })
     : [];
 
-  return [...dataColumns, actionsColumn];
+  return [selectColumn, ...dataColumns, actionsColumn];
 };
 
 export const rowsQuery = (

--- a/web/app/routes/tables/data-table.tsx
+++ b/web/app/routes/tables/data-table.tsx
@@ -3,6 +3,7 @@ import type {
   OnChangeFn,
   PaginationState,
   SortingState,
+  RowSelectionState,
 } from "@tanstack/react-table";
 
 import {
@@ -18,7 +19,14 @@ import {
   ChevronsLeftIcon,
   ChevronsRightIcon,
 } from "lucide-react";
-import React, { useState, useEffect, useRef, useMemo, Fragment } from "react";
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useMemo,
+  useCallback,
+  Fragment,
+} from "react";
 import { Button } from "~/components/ui/button";
 import { Label } from "~/components/ui/label";
 import {
@@ -48,207 +56,248 @@ interface DataTableProps<TData, TValue> {
   onPaginationChange: OnChangeFn<PaginationState>;
   onRowClick?: (row: TData) => void;
   tableMeta?: any;
+  onRowSelectionChange?: (selectedRows: TData[]) => void;
+  rowSelection?: RowSelectionState;
+  onRowSelectionStateChange?: OnChangeFn<RowSelectionState>;
 }
 
-export const DataTable = React.memo(<TData, TValue>({
-  columns,
-  data,
-  emptyMessage = "No results.",
-  pagination,
-  totalRows,
-  onPaginationChange,
-  onRowClick,
-  tableMeta,
-}: DataTableProps<TData, TValue>) => {
-  const tableRef = useRef<HTMLTableElement>(null);
-
-  const [sorting, setSorting] = useState<SortingState>([]);
-
-  const table = useReactTable({
-    data: Array.isArray(data) ? data : [],
+export const DataTable = React.memo(
+  <TData, TValue>({
     columns,
-    getCoreRowModel: getCoreRowModel(),
-    onSortingChange: setSorting,
-    getSortedRowModel: getSortedRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
-    manualPagination: true,
-    rowCount: totalRows,
-    onPaginationChange: onPaginationChange,
-    state: {
-      sorting,
-      pagination,
-    },
-    meta: tableMeta,
-  });
+    data,
+    emptyMessage = "No results.",
+    pagination,
+    totalRows,
+    onPaginationChange,
+    onRowClick,
+    tableMeta,
+    onRowSelectionChange,
+    rowSelection: controlledRowSelection,
+    onRowSelectionStateChange,
+  }: DataTableProps<TData, TValue>) => {
+    const tableRef = useRef<HTMLTableElement>(null);
 
-  return (
-    <div className="flex flex-col h-full">
-      <div className="flex-grow overflow-auto min-h-0 rounded-lg">
-        <Table ref={tableRef}>
-          <TableHeader className="sticky top-0 z-10 [&_tr:first-child_th:first-child]:rounded-tl-lg [&_tr:first-child_th:last-child]:rounded-tr-lg">
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => {
-                  return (
-                    <TableHead
-                      key={header.id}
-                      className={cn({
-                        "sticky-column":
-                          header.column.columnDef.meta &&
-                          (header.column.columnDef.meta as any).isSticky,
-                      })}
-                    >
-                      {header.isPlaceholder
-                        ? null
-                        : flexRender(
-                            header.column.columnDef.header,
-                            header.getContext()
-                          )}
-                    </TableHead>
-                  );
-                })}
-              </TableRow>
-            ))}
-          </TableHeader>
-          <TableBody>
-            {table.getRowModel().rows && table.getRowModel().rows.length > 0 ? (
-              table.getRowModel().rows.map((row) => (
-                <TableRow
-                  key={row.id}
-                  data-state={row.getIsSelected() && "selected"}
-                  className={cn(
-                    "data-table-row", 
-                    onRowClick && "cursor-pointer",
-                    (row.original as any)?.id === (table.options.meta as any)?.editingRowId && "bg-muted/50"
-                  )}
-                  onClick={() => onRowClick?.(row.original)}
-                  tabIndex={onRowClick ? 0 : undefined}
-                  onKeyDown={(e) => {
-                    if (onRowClick && (e.key === 'Enter' || e.key === ' ')) {
-                      e.preventDefault();
-                      onRowClick(row.original);
-                    }
-                  }}
-                >
-                  {row.getVisibleCells().map((cell) => {
+    const [sorting, setSorting] = useState<SortingState>([]);
+    const [internalRowSelection, setInternalRowSelection] =
+      useState<RowSelectionState>({});
+
+    // Use controlled selection if provided, otherwise use internal state
+    const rowSelection = controlledRowSelection ?? internalRowSelection;
+    const setRowSelection =
+      onRowSelectionStateChange ?? setInternalRowSelection;
+
+    // Notify parent of selection changes
+    useEffect(() => {
+      if (onRowSelectionChange) {
+        const selectedRows = Object.keys(rowSelection)
+          .filter((key) => rowSelection[key])
+          .map((index) => data[parseInt(index)])
+          .filter(Boolean);
+        onRowSelectionChange(selectedRows);
+      }
+    }, [rowSelection, data, onRowSelectionChange]);
+
+    // Memoize row click handler to prevent unnecessary re-renders
+    const handleRowClick = useCallback(
+      (row: TData) => {
+        if (onRowClick) {
+          onRowClick(row);
+        }
+      },
+      [onRowClick]
+    );
+
+    const table = useReactTable({
+      data: Array.isArray(data) ? data : [],
+      columns,
+      getCoreRowModel: getCoreRowModel(),
+      onSortingChange: setSorting,
+      getSortedRowModel: getSortedRowModel(),
+      getPaginationRowModel: getPaginationRowModel(),
+      manualPagination: true,
+      rowCount: totalRows,
+      onPaginationChange: onPaginationChange,
+      onRowSelectionChange: setRowSelection,
+      state: {
+        sorting,
+        pagination,
+        rowSelection,
+      },
+      meta: tableMeta,
+    });
+
+    return (
+      <div className="flex flex-col h-full">
+        <div className="flex-grow overflow-auto min-h-0 rounded-lg">
+          <Table ref={tableRef}>
+            <TableHeader className="sticky top-0 z-10 [&_tr:first-child_th:first-child]:rounded-tl-lg [&_tr:first-child_th:last-child]:rounded-tr-lg">
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => {
                     return (
-                      <TableCell
-                        key={cell.id}
+                      <TableHead
+                        key={header.id}
                         className={cn({
                           "sticky-column":
-                            cell.column.columnDef.meta &&
-                            (cell.column.columnDef.meta as any).isSticky,
+                            header.column.columnDef.meta &&
+                            (header.column.columnDef.meta as any).isSticky,
                         })}
                       >
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext()
-                        )}
-                      </TableCell>
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(
+                              header.column.columnDef.header,
+                              header.getContext()
+                            )}
+                      </TableHead>
                     );
                   })}
                 </TableRow>
-              ))
-            ) : (
-              <TableRow>
-                <TableCell
-                  colSpan={columns.length}
-                  className="h-24 text-center"
-                >
-                  {emptyMessage}
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
-      </div>
-      <div className="flex items-center justify-between px-4 py-2 border-t bg-background sticky bottom-0 z-10 rounded-b-lg">
-        <div className="hidden flex-1 text-sm text-muted-foreground lg:flex">
-          {table.getFilteredSelectedRowModel().rows.length > 0 &&
-            `${
-              table.getFilteredSelectedRowModel().rows.length
-            } of ${totalRows} row(s) selected`}
+              ))}
+            </TableHeader>
+            <TableBody>
+              {table.getRowModel().rows &&
+              table.getRowModel().rows.length > 0 ? (
+                table.getRowModel().rows.map((row) => (
+                  <TableRow
+                    key={row.id}
+                    data-state={row.getIsSelected() && "selected"}
+                    className={cn(
+                      "data-table-row",
+                      onRowClick && "cursor-pointer",
+                      (row.original as any)?.id ===
+                        (table.options.meta as any)?.editingRowId &&
+                        "bg-muted/50"
+                    )}
+                    onClick={() => handleRowClick(row.original)}
+                    tabIndex={onRowClick ? 0 : undefined}
+                    onKeyDown={(e) => {
+                      if (onRowClick && (e.key === "Enter" || e.key === " ")) {
+                        e.preventDefault();
+                        handleRowClick(row.original);
+                      }
+                    }}
+                  >
+                    {row.getVisibleCells().map((cell) => {
+                      return (
+                        <TableCell
+                          key={cell.id}
+                          className={cn({
+                            "sticky-column":
+                              cell.column.columnDef.meta &&
+                              (cell.column.columnDef.meta as any).isSticky,
+                          })}
+                        >
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext()
+                          )}
+                        </TableCell>
+                      );
+                    })}
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell
+                    colSpan={columns.length}
+                    className="h-24 text-center"
+                  >
+                    {emptyMessage}
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
         </div>
-        <div className="flex w-full items-center justify-end gap-8 lg:w-fit">
-          <div className="hidden items-center gap-2 lg:flex">
-            <Label htmlFor="rows-per-page" className="text-sm font-medium">
-              Rows per page
-            </Label>
-            <Select
-              value={`${table.getState().pagination.pageSize}`}
-              onValueChange={(value) => {
-                table.setPageSize(Number(value));
-              }}
-            >
-              <SelectTrigger className="w-20" id="rows-per-page">
-                <SelectValue
-                  placeholder={table.getState().pagination.pageSize}
-                />
-              </SelectTrigger>
-              <SelectContent side="top">
-                {[50, 100, 150, 200, 250].map((pageSize) => (
-                  <SelectItem key={pageSize} value={`${pageSize}`}>
-                    {pageSize}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+        <div className="flex items-center justify-between px-4 py-3 border-t bg-background sticky bottom-0 z-10 rounded-b-lg">
+          <div className="hidden flex-1 text-sm text-muted-foreground lg:flex">
+            {table.getFilteredSelectedRowModel().rows.length} of{" "}
+            {table.getFilteredRowModel().rows.length} row(s) selected.
           </div>
-          <div className="flex w-fit items-center justify-center text-sm font-medium">
-            Page {table.getState().pagination.pageIndex + 1} of{" "}
-            {Math.ceil(totalRows / pagination.pageSize) || 1}
-            <span className="ml-1 text-muted-foreground">
-              ({pagination.pageSize * pagination.pageIndex + 1}-
-              {Math.min(
-                pagination.pageSize * (pagination.pageIndex + 1),
-                totalRows
-              )}{" "}
-              of {totalRows})
-            </span>
-          </div>
-          <div className="ml-auto flex items-center gap-2 lg:ml-0">
-            <Button
-              variant="outline"
-              className="hidden h-8 w-8 p-0 lg:flex"
-              onClick={() => table.setPageIndex(0)}
-              disabled={!table.getCanPreviousPage()}
-            >
-              <span className="sr-only">Go to first page</span>
-              <ChevronsLeftIcon />
-            </Button>
-            <Button
-              variant="outline"
-              className="size-8"
-              size="icon"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              <span className="sr-only">Go to previous page</span>
-              <ChevronLeftIcon />
-            </Button>
-            <Button
-              variant="outline"
-              className="size-8"
-              size="icon"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              <span className="sr-only">Go to next page</span>
-              <ChevronRightIcon />
-            </Button>
-            <Button
-              variant="outline"
-              className="hidden size-8 lg:flex"
-              size="icon"
-              onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-              disabled={!table.getCanNextPage()}
-            >
-              <span className="sr-only">Go to last page</span>
-              <ChevronsRightIcon />
-            </Button>
+          <div className="flex  items-center justify-end gap-6 lg:gap-8 lg:w-fit">
+            <div className="hidden items-center gap-2 lg:flex">
+              <Label htmlFor="rows-per-page" className="text-sm font-medium">
+                Rows per page
+              </Label>
+              <Select
+                value={`${table.getState().pagination.pageSize}`}
+                onValueChange={(value) => {
+                  table.setPageSize(Number(value));
+                }}
+              >
+                <SelectTrigger className="w-20" id="rows-per-page">
+                  <SelectValue
+                    placeholder={table.getState().pagination.pageSize}
+                  />
+                </SelectTrigger>
+                <SelectContent side="top">
+                  {[50, 100, 150, 200, 250].map((pageSize) => (
+                    <SelectItem key={pageSize} value={`${pageSize}`}>
+                      {pageSize}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex w-fit items-center justify-center text-sm font-medium">
+              Page {table.getState().pagination.pageIndex + 1} of{" "}
+              {Math.ceil(totalRows / pagination.pageSize) || 1}
+              <span className="ml-1 text-muted-foreground">
+                ({pagination.pageSize * pagination.pageIndex + 1}-
+                {Math.min(
+                  pagination.pageSize * (pagination.pageIndex + 1),
+                  totalRows
+                )}{" "}
+                of {totalRows})
+              </span>
+            </div>
+            <div className="ml-auto flex items-center gap-2 lg:ml-0">
+              <Button
+                variant="outline"
+                className="hidden h-8 w-8 p-0 lg:flex"
+                onClick={() => table.setPageIndex(0)}
+                disabled={!table.getCanPreviousPage()}
+              >
+                <span className="sr-only">Go to first page</span>
+                <ChevronsLeftIcon />
+              </Button>
+              <Button
+                variant="outline"
+                className="size-8"
+                size="icon"
+                onClick={() => table.previousPage()}
+                disabled={!table.getCanPreviousPage()}
+              >
+                <span className="sr-only">Go to previous page</span>
+                <ChevronLeftIcon />
+              </Button>
+              <Button
+                variant="outline"
+                className="size-8"
+                size="icon"
+                onClick={() => table.nextPage()}
+                disabled={!table.getCanNextPage()}
+              >
+                <span className="sr-only">Go to next page</span>
+                <ChevronRightIcon />
+              </Button>
+              <Button
+                variant="outline"
+                className="hidden size-8 lg:flex"
+                size="icon"
+                onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+                disabled={!table.getCanNextPage()}
+              >
+                <span className="sr-only">Go to last page</span>
+                <ChevronsRightIcon />
+              </Button>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  );
-}) as <TData, TValue>(props: DataTableProps<TData, TValue>) => React.ReactElement;
+    );
+  }
+) as <TData, TValue>(
+  props: DataTableProps<TData, TValue>
+) => React.ReactElement;


### PR DESCRIPTION
## Summary
This PR adds bulk delete functionality for table rows, allowing users to select multiple rows and delete them in a single operation.

Closes #172

## Changes
- Added `deleteTableRows` method to PostgREST service using `id=in.(id1,id2,...)` syntax
- Modified DataTable component to support controlled row selection
- Added bulk delete button in table header that appears when rows are selected
- Added confirmation dialog with loading states
- Implemented keyboard shortcuts for better UX
- Fixed row selection state management to prevent selection shifting after deletion

## Features
- ✅ Row selection with checkboxes
- ✅ Bulk delete button in header (only visible when rows are selected)
- ✅ Shows count of selected rows
- ✅ Confirmation dialog before deletion
- ✅ Loading states during deletion
- ✅ Keyboard shortcuts:
  - `Ctrl/Cmd + A`: Select all rows on current page
  - `Delete`: Open bulk delete dialog
  - `Escape`: Clear selection
- ✅ Proper error handling with user-friendly messages
- ✅ Input validation and sanitization for security

## Testing
1. Navigate to any table with data
2. Select multiple rows using checkboxes
3. Click the "Delete X rows" button in the header
4. Confirm deletion in the dialog
5. Verify rows are deleted and selection is cleared
6. Test keyboard shortcuts
7. Test error cases (network errors, etc.)

## Screenshots
The bulk delete button appears in the header when rows are selected, showing the count of selected rows.