### PR TITLE
Fix: Redirect to logout on token expiry in projects page

### DIFF
--- a/web/app/routes/projects/page.tsx
+++ b/web/app/routes/projects/page.tsx
@@ -28,7 +28,7 @@ export function meta({}: Route.MetaArgs) {
 import { Label } from "~/components/ui/label";
 import { Input } from "~/components/ui/input";
 import { useEffect, useState } from "react";
-import {Textarea} from "~/components/ui/textarea";
+import { Textarea } from "~/components/ui/textarea";
 
 export async function loader({ request }: Route.LoaderArgs) {
   const authToken = await getServerAuthToken(request.headers);
@@ -47,9 +47,13 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const services = initializeServices(authToken);
 
-  const { content: projects } = await services.user.getUserProjects(
+  const { content: projects, ok } = await services.user.getUserProjects(
     organizationId
   );
+
+  if (!ok) {
+    return redirect("/logout");
+  }
 
   return { title: "Projects", projects: projects || [] };
 }
@@ -89,7 +93,11 @@ const CreateProjectDialog = ({ children }: { children: React.ReactNode }) => {
           <div className="grid gap-4">
             <div className="grid gap-3">
               <Label htmlFor="description">Description</Label>
-              <Textarea id="description" name="description" placeholder="What is this project about?" />
+              <Textarea
+                id="description"
+                name="description"
+                placeholder="What is this project about?"
+              />
             </div>
           </div>
           <DialogFooter>


### PR DESCRIPTION
## Summary
This PR fixes the issue where users were not being redirected when their authentication token expired on the projects page.

## Changes
- Added response status check in the projects page loader
- Implemented redirect to `/logout` when API calls fail (indicating expired token)
- Minor formatting fix for Textarea import

## Testing
1. Navigate to the projects page with a valid token
2. Wait for token to expire or manually invalidate it
3. Refresh the page or trigger a loader
4. User should be redirected to logout page

Fixes #174