### PR TITLE
FLX-28: Enable PostgREST logs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,14 +8,14 @@ on:
       - '*.md'
       - '.gitignore'
       - 'LICENSE'
-  pull_request:
-    branches: [ "main" ] # Build and test on PRs to main
-    paths-ignore:
-      - 'README.md'
-      - 'docs/**'
-      - '*.md'
-      - '.gitignore'
-      - 'LICENSE'
+  #pull_request:
+  #  branches: [ "main" ] # Build and test on PRs to main
+  #  paths-ignore:
+  #    - 'README.md'
+  #    - 'docs/**'
+  #    - '*.md'
+  #    - '.gitignore'
+  #    - 'LICENSE'
 
 env:
   REGISTRY: docker.io

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,14 +8,14 @@ on:
       - '*.md'
       - '.gitignore'
       - 'LICENSE'
-  #pull_request:
-  #  branches: [ "main" ] # Build and test on PRs to main
-  #  paths-ignore:
-  #    - 'README.md'
-  #    - 'docs/**'
-  #    - '*.md'
-  #    - '.gitignore'
-  #    - 'LICENSE'
+  pull_request:
+    branches: [ "main" ] # Build and test on PRs to main
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
+      - '*.md'
+      - '.gitignore'
+      - 'LICENSE'
 
 env:
   REGISTRY: docker.io
@@ -43,7 +43,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}:latest
           labels: |
@@ -60,7 +60,7 @@ jobs:
         with:
           context: ./web
           file: ./web/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}:latest
           labels: |

--- a/internal/adapters/postgrest/service.go
+++ b/internal/adapters/postgrest/service.go
@@ -159,6 +159,10 @@ func (s *ServiceImpl) buildStartCommand(dbName string) []string {
 		"--label", "traefik.enable=true",
 		"--label", fmt.Sprintf("traefik.http.routers.%s.rule=Host(`%s.%s`)", dbName, dbName, s.config.BaseDomain),
 		"--label", fmt.Sprintf("traefik.http.services.%s.loadbalancer.server.port=3000", dbName),
+
+		// Add tracking middleware
+		"--label", fmt.Sprintf("traefik.http.routers.%s.middlewares=track-%s", dbName, dbName),
+		"--label", fmt.Sprintf("traefik.http.middlewares.track-%s.forwardauth.address=%s://api.%s/projects/%s/logs/capture", dbName, s.config.URLScheme, s.config.BaseDomain, dbName),
 	}
 
 	if s.config.URLScheme == "https" {
@@ -172,7 +176,6 @@ func (s *ServiceImpl) buildStartCommand(dbName string) []string {
 	}
 
 	response = append(response, ImageName)
-
 	return response
 }
 

--- a/internal/api/dto/logging/mapper.go
+++ b/internal/api/dto/logging/mapper.go
@@ -17,3 +17,13 @@ func ToLogListInput(request *ListRequest, projectUUID uuid.NullUUID) *logging.Li
 		EndTime:     request.EndTime,
 	}
 }
+
+func ToLogStoreInput(request *StoreRequest, dbName string) *logging.StoreInput {
+	return &logging.StoreInput{
+		Endpoint:  request.Endpoint,
+		DbName:    dbName,
+		IPAddress: request.IPAddress,
+		Host:      request.Host,
+		Method:    request.Method,
+	}
+}

--- a/internal/api/dto/logging/requests.go
+++ b/internal/api/dto/logging/requests.go
@@ -56,3 +56,25 @@ func (r *ListRequest) BindAndValidate(c echo.Context) []string {
 
 	return nil
 }
+
+type StoreRequest struct {
+	dto.BaseRequest
+	Endpoint  string `json:"endpoint"`
+	DbName    string `json:"DbName"`
+	IPAddress string `json:"ipAddress"`
+	Host      string `json:"host"`
+	Method    string `json:"method"`
+}
+
+func (r *StoreRequest) BindAndValidate(c echo.Context) []string {
+	if err := c.Bind(r); err != nil {
+		return []string{"Invalid request payload"}
+	}
+
+	r.Method = c.Request().Header.Get("X-Forwarded-Method")
+	r.Endpoint = c.Request().Header.Get("X-Forwarded-Uri")
+	r.Host = c.Request().Header.Get("X-Forwarded-Host")
+	r.IPAddress = c.Request().Header.Get("X-Real-Ip")
+
+	return nil
+}

--- a/internal/api/middlewares/request_logger.go
+++ b/internal/api/middlewares/request_logger.go
@@ -30,6 +30,12 @@ func RequestLogger(requestLogRepo logging.Repository) echo.MiddlewareFunc {
 				}
 			}
 
+			if strings.Contains(c.Request().URL.Path, "logs/capture") {
+				// Skip logging for the PostgREST capture endpoint
+				// This is used to capture logs from PostgREST requests
+				return next(c)
+			}
+
 			request := c.Request()
 			requestBody := readBody(request)
 

--- a/internal/api/routes/project.go
+++ b/internal/api/routes/project.go
@@ -21,4 +21,7 @@ func RegisterProjectRoutes(e *echo.Echo, container *do.Injector, authMiddleware 
 	projectsGroup.GET("/:projectUUID/logs", projectController.ListLogs)
 
 	projectsGroup.GET("/:projectUUID/stats", statHandler.Retrieve)
+
+	// track postgrest requests
+	e.GET("projects/:dbName/logs/capture", projectController.StoreLogs)
 }

--- a/internal/database/repositories/request_log.go
+++ b/internal/database/repositories/request_log.go
@@ -151,3 +151,25 @@ func (r *RequestLogRepository) Create(requestLog *logging.RequestLog) (*logging.
 		).Scan(&requestLog.Uuid)
 	})
 }
+
+func (r *RequestLogRepository) CreatePostgrest(storeInput *logging.StoreInput) error {
+	query := `
+		INSERT INTO fluxend.api_logs (
+			project_uuid, method, endpoint, ip_address, status, user_agent
+		) VALUES (
+			$1, $2, $3, $4, $5, $6
+		)
+	`
+
+	_, err := r.db.Exec(
+		query,
+		storeInput.ProjectUUID,
+		storeInput.Method,
+		storeInput.Endpoint,
+		storeInput.IPAddress,
+		200,
+		"postgrest",
+	)
+
+	return err
+}

--- a/internal/domain/logging/repository.go
+++ b/internal/domain/logging/repository.go
@@ -7,4 +7,5 @@ import (
 type Repository interface {
 	List(input *ListInput, paginationParams shared.PaginationParams) ([]RequestLog, shared.PaginationDetails, error)
 	Create(requestLog *RequestLog) (*RequestLog, error)
+	CreatePostgrest(storeInput *StoreInput) error
 }

--- a/internal/domain/logging/types.go
+++ b/internal/domain/logging/types.go
@@ -16,3 +16,12 @@ type ListInput struct {
 	StartTime   time.Time     `query:"startTime"`
 	EndTime     time.Time     `query:"endTime"`
 }
+
+type StoreInput struct {
+	Endpoint    string    `json:"endpoint"`
+	DbName      string    `json:"DbName"`
+	ProjectUUID uuid.UUID `json:"projectUuid"`
+	IPAddress   string    `json:"ipAddress"`
+	Host        string    `json:"host"`
+	Method      string    `json:"method"`
+}


### PR DESCRIPTION
**Why**
PostgREST requests are black hole at the moment. A user will have no idea what's happening in backend, how many requests are taking place and so on.

**Changes**
- Adds endpoint to capture logs
- Adds Traefik middleware to pass postgrest requests to endpoint
