### PR TITLE
Fix: Connect Create Container button in storage empty state

### DIFF
--- a/web/app/routes/storage/index.tsx
+++ b/web/app/routes/storage/index.tsx
@@ -12,6 +12,8 @@ import { ContainerList } from "~/components/storage/container-list";
 
 interface StorageLayoutContext extends ProjectLayoutOutletContext {
   containers: StorageContainer[];
+  isContainersLoading?: boolean;
+  setCreateContainerOpen?: (open: boolean) => void;
 }
 
 export function meta({}: Route.MetaArgs) {
@@ -22,7 +24,7 @@ export function meta({}: Route.MetaArgs) {
 }
 
 export default function StorageIndex() {
-  const { projectDetails, services, containers } = useOutletContext<StorageLayoutContext>();
+  const { projectDetails, services, containers, isContainersLoading, setCreateContainerOpen } = useOutletContext<StorageLayoutContext>();
   const projectId = projectDetails?.uuid;
   const queryClient = useQueryClient();
 
@@ -51,7 +53,7 @@ export default function StorageIndex() {
 
       {/* Content */}
       <div className="flex-1 overflow-hidden p-4">
-        {!containers.length ? (
+        {isContainersLoading ? (
           <div className="rounded-lg border h-full overflow-hidden">
             <DataTableSkeleton columns={5} rows={8} />
           </div>
@@ -68,7 +70,7 @@ export default function StorageIndex() {
               <p className="text-muted-foreground mb-4">
                 No containers yet. Create your first container to get started.
               </p>
-              <Button onClick={() => {}}>
+              <Button onClick={() => setCreateContainerOpen?.(true)}>
                 <Plus className="h-4 w-4 mr-2" />
                 Create Container
               </Button>

--- a/web/app/routes/storage/sidebar.tsx
+++ b/web/app/routes/storage/sidebar.tsx
@@ -106,7 +106,7 @@ export default function StorageLayout() {
         />
         <SidebarInset className="flex-1 overflow-hidden">
           <div className="h-full overflow-auto">
-            <Outlet context={{ projectDetails, services, containers }} />
+            <Outlet context={{ projectDetails, services, containers, isContainersLoading, setCreateContainerOpen }} />
           </div>
         </SidebarInset>
 

--- a/web/app/services/storage.ts
+++ b/web/app/services/storage.ts
@@ -272,7 +272,7 @@ export function createStorageService(authToken: string) {
     };
 
     const response = await put(
-      `/containers/${containerUuid}/files/${fileUuid}/rename`,
+      `/containers/${containerUuid}/files/${fileUuid}`,
       renameData,
       fetchOptions
     );

--- a/web/app/services/storage.ts
+++ b/web/app/services/storage.ts
@@ -272,7 +272,7 @@ export function createStorageService(authToken: string) {
     };
 
     const response = await put(
-      `/containers/${containerUuid}/files/${fileUuid}`,
+      `/containers/${containerUuid}/files/${fileUuid}/rename`,
       renameData,
       fetchOptions
     );


### PR DESCRIPTION
## Summary
- Fixed the Create Container button in the storage index page that wasn't opening the dialog
- Pass setCreateContainerOpen callback through outlet context from sidebar to child routes
- This allows users to create containers when viewing the empty state message

## Related Issue
Partially addresses #191 - the Create Container button now works when no containers exist

## Test Plan
1. Navigate to Storage page with no containers
2. Click the "Create Container" button in the empty state
3. Verify the Create Container dialog opens
4. Create a container and verify navigation to the new container